### PR TITLE
Update talker scripts

### DIFF
--- a/root/scripts/talker/biker.txt
+++ b/root/scripts/talker/biker.txt
@@ -65,7 +65,7 @@ Response L4D1ReviveMeInterruptedMinorBiker
 }
 Rule L4D1ReviveMeInterruptedMinorBiker
 {
-	criteria ConceptReviveMeInterrupted IsBiker IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsBiker IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMinorBiker
@@ -87,7 +87,7 @@ Response L4D1ReviveMeInterruptedMajorBiker
 }
 Rule L4D1ReviveMeInterruptedMajorBiker
 {
-	criteria ConceptReviveMeInterrupted IsBiker IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsBiker IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMajorBiker
@@ -4354,7 +4354,7 @@ Response L4D1PlayerHelpIncappedBiker
 }
 Rule L4D1PlayerHelpIncappedBiker
 {
-	criteria ConceptPlayerHelp IsBiker IsNotCoughing IsTalk IsTalkBiker IsIncapacitated IsIncappedStarted IsIncappedStarted2 NotCalledForHelpRecently IsWorldTalkBiker
+	criteria ConceptPlayerHelp IsBiker IsNotCoughing IsTalk IsTalkBiker IsIncapacitated IsIncappedStarted NotCalledForHelpRecently IsWorldTalkBiker
 	ApplyContext "CalledForHelp:1:15"
 	Response L4D1PlayerHelpIncappedBiker
 }
@@ -4386,7 +4386,7 @@ Response L4D1PlayerHelpIncappedBleedingBiker
 }
 Rule L4D1PlayerHelpIncappedBleedingBiker
 {
-	criteria ConceptPlayerHelp IsBiker IsNotCoughing IsTalk IsTalkBiker IsIncapacitated IsIncappedBleeding1 IsIncappedBleeding2 NotCalledForHelpRecently IsWorldTalkBiker
+	criteria ConceptPlayerHelp IsBiker IsNotCoughing IsTalk IsTalkBiker IsIncapacitated IsIncappedBleeding NotCalledForHelpRecently IsWorldTalkBiker
 	ApplyContext "CalledForHelp:1:30"
 	Response L4D1PlayerHelpIncappedBleedingBiker
 }

--- a/root/scripts/talker/coach.txt
+++ b/root/scripts/talker/coach.txt
@@ -961,7 +961,7 @@ Response ReviveMeInterruptedCoach
 }
 Rule ReviveMeInterruptedCoach
 {
-	criteria ConceptReviveMeInterrupted IsCoach IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsCoach IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedCoach
@@ -983,7 +983,7 @@ Response ReviveMeInterruptedMajorCoach
 }
 Rule ReviveMeInterruptedMajorCoach
 {
-	criteria ConceptReviveMeInterrupted IsCoach IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsCoach IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMajorCoach
@@ -6386,7 +6386,7 @@ Response PlayerHelpIncappedCoach
 }
 Rule PlayerHelpIncappedCoach
 {
-	criteria ConceptPlayerHelp IsCoach IsNotCoughing IsTalk IsTalkCoach IsIncapacitated IsIncappedStarted IsIncappedStarted2 NotCalledForHelpRecently IsWorldTalkCoach
+	criteria ConceptPlayerHelp IsCoach IsNotCoughing IsTalk IsTalkCoach IsIncapacitated IsIncappedStarted NotCalledForHelpRecently IsWorldTalkCoach
 	ApplyContext "CalledForHelp:1:7.5"
 	Response PlayerHelpIncappedCoach
 }
@@ -6401,7 +6401,7 @@ Response PlayerHelpIncappedBleedingCoach
 }
 Rule PlayerHelpIncappedBleedingCoach
 {
-	criteria ConceptPlayerHelp IsCoach IsNotCoughing IsTalk IsTalkCoach IsIncapacitated IsIncappedBleeding1 IsIncappedBleeding2 NotCalledForHelpRecently IsWorldTalkCoach
+	criteria ConceptPlayerHelp IsCoach IsNotCoughing IsTalk IsTalkCoach IsIncapacitated IsIncappedBleeding NotCalledForHelpRecently IsWorldTalkCoach
 	ApplyContext "CalledForHelp:1:15"
 	Response PlayerHelpIncappedBleedingCoach
 }
@@ -8407,7 +8407,7 @@ Response PlayerRemarkWorldC1M1ElevatorBrokenCoach
 }
 Rule PlayerRemarkWorldC1M1ElevatorBrokenCoach
 {
-	criteria ConceptRemark IsCoach IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsNotAlone IsTalk IsTalkCoach IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkCoach IsNotSpeakingWeight0
+	criteria ConceptRemark IsCoach IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsTalk IsTalkCoach IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkCoach IsNotSpeakingWeight0
 	ApplyContext "SaidWorldC1M1ElevatorBroken:1:0"
 	applycontexttoworld
 	Response PlayerRemarkWorldC1M1ElevatorBrokenCoach

--- a/root/scripts/talker/gambler.txt
+++ b/root/scripts/talker/gambler.txt
@@ -315,7 +315,7 @@ Response Playerc1m1_enter_elevatorGambler
 }
 Rule Playerc1m1_enter_elevatorGambler
 {
-	criteria Conceptc1m1_enter_elevator IsGambler IsTalk IsTalkGambler IsNotSaidc1m1_enter_elevator AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkGambler
+	criteria Conceptc1m1_enter_elevator IsGambler IsTalk IsTalkGambler IsNotAlone IsNotSaidc1m1_enter_elevator AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkGambler
 	ApplyContext "Saidc1m1_enter_elevator:1:0"
 	applycontexttoworld
 	Response Playerc1m1_enter_elevatorGambler
@@ -827,7 +827,7 @@ Response ReviveMeInterruptedMinorGambler
 }
 Rule ReviveMeInterruptedMinorGambler
 {
-	criteria ConceptReviveMeInterrupted IsGambler IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsGambler IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMinorGambler
@@ -849,7 +849,7 @@ Response ReviveMeInterruptedMajorGambler
 }
 Rule ReviveMeInterruptedMajorGambler
 {
-	criteria ConceptReviveMeInterrupted IsGambler IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsGambler IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMajorGambler
@@ -6507,7 +6507,7 @@ Response PlayerHelpIncappedGambler
 }
 Rule PlayerHelpIncappedGambler
 {
-	criteria ConceptPlayerHelp IsGambler IsNotCoughing IsTalk IsTalkGambler IsIncappedStarted IsIncappedStarted2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkGambler
+	criteria ConceptPlayerHelp IsGambler IsNotCoughing IsTalk IsTalkGambler IsIncappedStarted IsIncapacitated NotCalledForHelpRecently IsWorldTalkGambler
 	ApplyContext "CalledForHelp:1:7.5"
 	Response PlayerHelpIncappedGambler
 }
@@ -6520,7 +6520,7 @@ Response PlayerHelpIncappedBleedingGambler
 }
 Rule PlayerHelpIncappedBleedingGambler
 {
-	criteria ConceptPlayerHelp IsGambler IsNotCoughing IsTalk IsTalkGambler IsIncappedBleeding1 IsIncappedBleeding2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkGambler
+	criteria ConceptPlayerHelp IsGambler IsNotCoughing IsTalk IsTalkGambler IsIncappedBleeding IsIncapacitated NotCalledForHelpRecently IsWorldTalkGambler
 	ApplyContext "CalledForHelp:1:15"
 	Response PlayerHelpIncappedBleedingGambler
 }
@@ -8582,7 +8582,7 @@ Response PlayerRemarkWorldC1M1ElevatorBrokenGambler
 }
 Rule PlayerRemarkWorldC1M1ElevatorBrokenGambler
 {
-	criteria ConceptRemark IsGambler IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsNotAlone IsTalk IsTalkGambler IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkGambler IsNotSpeakingWeight0
+	criteria ConceptRemark IsGambler IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsTalk IsTalkGambler IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkGambler IsNotSpeakingWeight0
 	ApplyContext "SaidWorldC1M1ElevatorBroken:1:0"
 	applycontexttoworld
 	Response PlayerRemarkWorldC1M1ElevatorBrokenGambler

--- a/root/scripts/talker/manager.txt
+++ b/root/scripts/talker/manager.txt
@@ -44,7 +44,7 @@ Response L4D1ReviveMeInterruptedMinorManager
 }
 Rule L4D1ReviveMeInterruptedMinorManager
 {
-	criteria ConceptReviveMeInterrupted IsManager IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsManager IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMinorManager
@@ -65,7 +65,7 @@ Response L4D1ReviveMeInterruptedMajorManager
 }
 Rule L4D1ReviveMeInterruptedMajorManager
 {
-	criteria ConceptReviveMeInterrupted IsManager IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsManager IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMajorManager
@@ -3487,7 +3487,7 @@ Response L4D1PlayerHelpIncappedManager
 }
 Rule L4D1PlayerHelpIncappedManager
 {
-	criteria ConceptPlayerHelp IsManager IsNotCoughing IsTalk IsTalkManager IsIncappedStarted IsIncappedStarted2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkManager
+	criteria ConceptPlayerHelp IsManager IsNotCoughing IsTalk IsTalkManager IsIncappedStarted IsIncapacitated NotCalledForHelpRecently IsWorldTalkManager
 	ApplyContext "CalledForHelp:1:7.5"
 	Response L4D1PlayerHelpIncappedManager
 }
@@ -3501,7 +3501,7 @@ Response L4D1PlayerHelpIncappedBleedingManager
 }
 Rule L4D1PlayerHelpIncappedBleedingManager
 {
-	criteria ConceptPlayerHelp IsManager IsNotCoughing IsTalk IsTalkManager IsIncappedBleeding1 IsIncappedBleeding2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkManager
+	criteria ConceptPlayerHelp IsManager IsNotCoughing IsTalk IsTalkManager IsIncappedBleeding IsIncapacitated NotCalledForHelpRecently IsWorldTalkManager
 	ApplyContext "CalledForHelp:1:15"
 	Response L4D1PlayerHelpIncappedBleedingManager
 }

--- a/root/scripts/talker/mechanic.txt
+++ b/root/scripts/talker/mechanic.txt
@@ -327,7 +327,7 @@ Response Playerc1m1_enter_elevatorMechanic
 }
 Rule Playerc1m1_enter_elevatorMechanic
 {
-	criteria Conceptc1m1_enter_elevator IsMechanic IsTalk IsTalkMechanic IsNotSaidc1m1_enter_elevator AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkMechanic
+	criteria Conceptc1m1_enter_elevator IsMechanic IsTalk IsTalkMechanic IsNotAlone IsNotSaidc1m1_enter_elevator AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkMechanic
 	ApplyContext "Saidc1m1_enter_elevator:1:0"
 	applycontexttoworld
 	Response Playerc1m1_enter_elevatorMechanic
@@ -951,7 +951,7 @@ Response ReviveMeInterruptedMinorMechanic
 }
 Rule ReviveMeInterruptedMinorMechanic
 {
-	criteria ConceptReviveMeInterrupted IsMechanic IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsMechanic IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMinorMechanic
@@ -968,7 +968,7 @@ Response ReviveMeInterruptedMajorMechanic
 }
 Rule ReviveMeInterruptedMajorMechanic
 {
-	criteria ConceptReviveMeInterrupted IsMechanic IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsMechanic IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMajorMechanic
@@ -7063,7 +7063,7 @@ Response PlayerHelpIncappedMechanic
 }
 Rule PlayerHelpIncappedMechanic
 {
-	criteria ConceptPlayerHelp IsMechanic IsNotCoughing IsTalk IsTalkMechanic IsIncappedStarted IsIncappedStarted2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkMechanic
+	criteria ConceptPlayerHelp IsMechanic IsNotCoughing IsTalk IsTalkMechanic IsIncappedStarted IsIncapacitated NotCalledForHelpRecently IsWorldTalkMechanic
 	ApplyContext "CalledForHelp:1:7.5"
 	Response PlayerHelpIncappedMechanic
 }
@@ -7079,7 +7079,7 @@ Response PlayerHelpIncappedBleeingMechanic
 }
 Rule PlayerHelpIncappedBleeingMechanic
 {
-	criteria ConceptPlayerHelp IsMechanic IsNotCoughing IsTalk IsTalkMechanic IsIncappedBleeding1 IsIncappedBleeding2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkMechanic
+	criteria ConceptPlayerHelp IsMechanic IsNotCoughing IsTalk IsTalkMechanic IsIncappedBleeding IsIncapacitated NotCalledForHelpRecently IsWorldTalkMechanic
 	ApplyContext "CalledForHelp:1:15"
 	Response PlayerHelpIncappedBleeingMechanic
 }
@@ -8956,7 +8956,7 @@ Response PlayerRemarkWorldC1M1ElevatorBrokenMechanic
 }
 Rule PlayerRemarkWorldC1M1ElevatorBrokenMechanic
 {
-	criteria ConceptRemark IsMechanic IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsNotAlone IsTalk IsTalkMechanic IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkMechanic IsNotSpeakingWeight0
+	criteria ConceptRemark IsMechanic IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsTalk IsTalkMechanic IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkMechanic IsNotSpeakingWeight0
 	ApplyContext "SaidWorldC1M1ElevatorBroken:1:0"
 	applycontexttoworld
 	Response PlayerRemarkWorldC1M1ElevatorBrokenMechanic

--- a/root/scripts/talker/namvet.txt
+++ b/root/scripts/talker/namvet.txt
@@ -71,7 +71,7 @@ Response L4D1ReviveMeInterruptedMinorNamVet
 }
 Rule L4D1ReviveMeInterruptedMinorNamVet
 {
-	criteria ConceptReviveMeInterrupted IsNamVet IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsNamVet IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMinorNamVet
@@ -91,7 +91,7 @@ Response L4D1ReviveMeInterruptedMajorNamVet
 }
 Rule L4D1ReviveMeInterruptedMajorNamVet
 {
-	criteria ConceptReviveMeInterrupted IsNamVet IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsNamVet IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMajorNamVet
@@ -2957,7 +2957,7 @@ Response L4D1PlayerHelpIncappedNamVet
 }
 Rule L4D1PlayerHelpIncappedNamVet
 {
-	criteria ConceptPlayerHelp IsNamVet IsNotCoughing IsTalk IsTalkNamVet IsIncappedStarted IsIncappedStarted2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkNamVet
+	criteria ConceptPlayerHelp IsNamVet IsNotCoughing IsTalk IsTalkNamVet IsIncappedStarted IsIncapacitated NotCalledForHelpRecently IsWorldTalkNamVet
 	ApplyContext "CalledForHelp:1:7.5"
 	Response L4D1PlayerHelpIncappedNamVet
 }
@@ -2976,7 +2976,7 @@ Response L4D1PlayerHelpIncapped2NamVet
 }
 Rule L4D1PlayerHelpIncapped2NamVet
 {
-	criteria ConceptPlayerHelp IsNamVet IsNotCoughing IsTalk IsTalkNamVet IsIncapacitated IsIncappedBleeding1 IsIncappedBleeding2 NotCalledForHelpRecently IsWorldTalkNamVet
+	criteria ConceptPlayerHelp IsNamVet IsNotCoughing IsTalk IsTalkNamVet IsIncapacitated IsIncappedBleeding NotCalledForHelpRecently IsWorldTalkNamVet
 	ApplyContext "CalledForHelp:1:15"
 	Response L4D1PlayerHelpIncapped2NamVet
 }

--- a/root/scripts/talker/producer.txt
+++ b/root/scripts/talker/producer.txt
@@ -234,7 +234,7 @@ Response Playerc1m1_enter_elevatorProducer
 }
 Rule Playerc1m1_enter_elevatorProducer
 {
-	criteria Conceptc1m1_enter_elevator IsProducer IsTalk IsTalkProducer IsNotSaidc1m1_enter_elevator AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkProducer
+	criteria Conceptc1m1_enter_elevator IsProducer IsTalk IsTalkProducer IsNotAlone IsNotSaidc1m1_enter_elevator AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkProducer
 	ApplyContext "Saidc1m1_enter_elevator:1:0"
 	applycontexttoworld
 	Response Playerc1m1_enter_elevatorProducer
@@ -777,7 +777,7 @@ Response ReviveMeInterruptedMinorProducer
 }
 Rule ReviveMeInterruptedMinorProducer
 {
-	criteria ConceptReviveMeInterrupted IsProducer IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsProducer IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMinorProducer
@@ -792,7 +792,7 @@ Response ReviveMeInterruptedMajorProducer
 }
 Rule ReviveMeInterruptedMajorProducer
 {
-	criteria ConceptReviveMeInterrupted IsProducer IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsProducer IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response ReviveMeInterruptedMajorProducer
@@ -6125,7 +6125,7 @@ Response PlayerHelpIncappedProducer
 }
 Rule PlayerHelpIncappedProducer
 {
-	criteria ConceptPlayerHelp IsProducer IsNotCoughing IsTalk IsTalkProducer IsIncappedStarted IsIncappedStarted2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkProducer
+	criteria ConceptPlayerHelp IsProducer IsNotCoughing IsTalk IsTalkProducer IsIncappedStarted IsIncapacitated NotCalledForHelpRecently IsWorldTalkProducer
 	ApplyContext "CalledForHelp:1:7.5"
 	Response PlayerHelpIncappedProducer
 }
@@ -6138,7 +6138,7 @@ Response PlayerHelpIncappedBleedingProducer
 }
 Rule PlayerHelpIncappedBleedingProducer
 {
-	criteria ConceptPlayerHelp IsProducer IsNotCoughing IsTalk IsTalkProducer IsIncappedBleeding1 IsIncappedBleeding2 IsIncapacitated NotCalledForHelpRecently IsWorldTalkProducer
+	criteria ConceptPlayerHelp IsProducer IsNotCoughing IsTalk IsTalkProducer IsIncappedBleeding IsIncapacitated NotCalledForHelpRecently IsWorldTalkProducer
 	ApplyContext "CalledForHelp:1:15"
 	Response PlayerHelpIncappedBleedingProducer
 }
@@ -7965,7 +7965,7 @@ Response PlayerRemarkWorldC1M1ElevatorBrokenProducer
 }
 Rule PlayerRemarkWorldC1M1ElevatorBrokenProducer
 {
-	criteria ConceptRemark IsProducer IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsNotAlone IsTalk IsTalkProducer IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkProducer IsNotSpeakingWeight0
+	criteria ConceptRemark IsProducer IsWorldC1M1ElevatorBroken IsNotSaidWorldC1M1ElevatorBroken IsNotCoughing NotInCombat IsTalk IsTalkProducer IsSubjectNear200 AutoIsNotScavenge AutoIsNotSurvival IsWorldTalkProducer IsNotSpeakingWeight0
 	ApplyContext "SaidWorldC1M1ElevatorBroken:1:0"
 	applycontexttoworld
 	Response PlayerRemarkWorldC1M1ElevatorBrokenProducer

--- a/root/scripts/talker/teengirl.txt
+++ b/root/scripts/talker/teengirl.txt
@@ -57,7 +57,7 @@ Response L4D1ReviveMeInterruptedMinorTeenGirl
 }
 Rule L4D1ReviveMeInterruptedMinorTeenGirl
 {
-	criteria ConceptReviveMeInterrupted IsTeenGirl IsIncappedStarted IsIncappedStarted2
+	criteria ConceptReviveMeInterrupted IsTeenGirl IsIncappedStarted
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMinorTeenGirl
@@ -74,7 +74,7 @@ Response L4D1ReviveMeInterruptedMajorTeenGirl
 }
 Rule L4D1ReviveMeInterruptedMajorTeenGirl
 {
-	criteria ConceptReviveMeInterrupted IsTeenGirl IsIncappedBleeding1 IsIncappedBleeding2
+	criteria ConceptReviveMeInterrupted IsTeenGirl IsIncappedBleeding
 	ApplyContext "ReviveInterrupt:1:2"
 	applycontexttoworld
 	Response L4D1ReviveMeInterruptedMajorTeenGirl
@@ -3708,7 +3708,7 @@ Response L4D1PlayerHelpIncappedTeenGirl
 }
 Rule L4D1PlayerHelpIncappedTeenGirl
 {
-	criteria ConceptPlayerHelp IsTeenGirl IsNotCoughing IsTalk IsTalkTeenGirl IsIncapacitated IsIncappedStarted IsIncappedStarted2 NotCalledForHelpRecently IsWorldTalkTeenGirl
+	criteria ConceptPlayerHelp IsTeenGirl IsNotCoughing IsTalk IsTalkTeenGirl IsIncapacitated IsIncappedStarted NotCalledForHelpRecently IsWorldTalkTeenGirl
 	ApplyContext "CalledForHelp:1:7.5"
 	Response L4D1PlayerHelpIncappedTeenGirl
 }
@@ -3729,7 +3729,7 @@ Response L4D1PlayerHelpIncappedBleedingTeenGirl
 }
 Rule L4D1PlayerHelpIncappedBleedingTeenGirl
 {
-	criteria ConceptPlayerHelp IsTeenGirl IsNotCoughing IsTalk IsTalkTeenGirl IsIncapacitated IsIncappedBleeding1 IsIncappedBleeding2 NotCalledForHelpRecently IsWorldTalkTeenGirl
+	criteria ConceptPlayerHelp IsTeenGirl IsNotCoughing IsTalk IsTalkTeenGirl IsIncapacitated IsIncappedBleeding NotCalledForHelpRecently IsWorldTalkTeenGirl
 	ApplyContext "CalledForHelp:1:15"
 	Response L4D1PlayerHelpIncappedBleedingTeenGirl
 }

--- a/root/scripts/talker/terror_player.txt
+++ b/root/scripts/talker/terror_player.txt
@@ -457,10 +457,8 @@ criterion "IsTankDominated"  "AwardName" "HulkShutOut" required
 
 criterion "IsCarAlarm"  "PanicType" "CarAlarm" required
 
-criterion "IsIncappedStarted"   "healthfrac" "<2.99"	  required
-criterion "IsIncappedStarted2"   "healthfrac" ">1.99"	  required
-criterion "IsIncappedBleeding1"   "healthfrac" "<1.99"	  required
-criterion "IsIncappedBleeding2"   "healthfrac" ">.99"	  required
+criterion "IsIncappedStarted"   "healthfrac" ">1.99,<2.99"	  required
+criterion "IsIncappedBleeding"   "healthfrac" ">.99,<1.99"	  required
 criterion "IsIncappedLethargic"   "healthfrac" "<.99"	  required
 
 criterion "IsFullHealth"   "healthfrac" ">.99"	  required


### PR DESCRIPTION
- Updated criteria definitions for IsIncappedStarted and IsIncappedBleeding.
- Removed IsNotAlone from C1M1Elevator remarks.
- Added missing IsNotAlone to the c1m1_enter_elevator concept for Gambler, Mechanic and Producer.