### PR TITLE
Various small map fixes

### DIFF
--- a/root/scripts/vscripts/community/maps/c10m3_ranchhouse.nut
+++ b/root/scripts/vscripts/community/maps/c10m3_ranchhouse.nut
@@ -77,6 +77,7 @@ function DoRoundFixes()
 		make_clip(	"_solidify_permstuck07",	"SI Players",	1,	"-17 -17 0",		"17 17 512",		"-8918 -860 -42" );
 		make_clip(	"_solidify_permstuck08",	"SI Players",	1,	"-17 -17 0",		"17 17 512",		"-8570 -994 -66" );
 		make_clip( "_meticulous_funcinfclip01", "SI Players", 1, "-508 -290 -72", "1134 46 402", "-9348 -7694 584" );
+		make_clip( "_hellcade_permstuck",		"SI Players", 1, "-13 -188 -24", "13 188 24", "-4598 -1025 -54" );
 		make_ladder( "_ladder_brokenwallL_cloned_graveshort", "-4808 706 6", "2295 383 193" );
 		make_ladder( "_ladder_brokenwallM_cloned_graveshort", "-4808 706 6", "2327 383 193" );
 		make_ladder( "_ladder_brokenwallR_cloned_graveshort", "-4808 706 6", "2359 383 193" );

--- a/root/scripts/vscripts/community/maps/c14m2_lighthouse.nut
+++ b/root/scripts/vscripts/community/maps/c14m2_lighthouse.nut
@@ -26,6 +26,16 @@ function DoRoundFixes()
 			}
 		}
 	}
+	
+	if ( g_BaseMode == "versus" )
+	{
+		devchap( "BASE VERSUS" );
+
+		// FIXES
+
+		make_clip( "_permstuck_treefence", "Everyone", 1, "-8 -8 -27", "8 8 27", "-2552 4572 482" );
+
+	}
 
 	if ( HasPlayerControlledZombies() )
 	{

--- a/root/scripts/vscripts/community/maps/c1m2_streets.nut
+++ b/root/scripts/vscripts/community/maps/c1m2_streets.nut
@@ -22,8 +22,8 @@ PrecacheModel( "models/props_foliage/urban_hedge_256_128_high.mdl" );
 
 function DoRoundFixes()
 {
-	make_clip(	"_mindthegap_lolvalve",		"SI Players",	1,	"-32 -4 -64",		"32 4 64",		"-2472 137 64" );
-	make_clip(	"_stuckwarpassist_walltovoid",	"SI Players",	1,	"-1536 -476 -5",	"0 500 0",		"-5056 1500 1344" );
+	make_clip( "_mindthegap_lolvalve",		"SI Players",	1,	"-32 -4 -64",		"32 4 64",		"-2472 137 64" );
+	make_clip( "_stuckwarpassist_walltovoid",	"SI Players",	1,	"-1536 -476 -5",	"0 500 0",		"-5056 1500 1344" );
 	make_clip( "_nav_cedaramp_in", "SI Players and AI", 1, "0 -18 -14", "10 21 51", "-4268 2566 75", "-50 -35 0" );
 	make_clip( "_nav_cedaramp_out", "SI Players and AI", 1, "-95 -20 4", "38 17 11", "-4322 2567 102", "-8 0 0" );
 	make_clip( "_colastore_clipgap", "Survivors", 1, "-8 -97 0", "8 75 856", "-6792 -3215 616" );
@@ -32,24 +32,15 @@ function DoRoundFixes()
 	make_clip( "_save4lesscurb_smoother1", "Everyone", 1, "-7 -110 0", "14 113 5", "-6515 -2681 384" );
 	make_clip( "_save4lesscurb_smoother2", "Everyone", 1, "-7 -127 0", "14 129 5", "-6515 -2302 384" );
 	make_clip( "_save4lesscurb_smoother3", "Everyone", 1, "-7 -432 0", "9 435 5", "-6899 -1601 384" );
-	make_clip("_ladderqol_smootherl", "Everyone", 1, "-7 -190 0", "7 190 2", "-6059 -2238 430", "-45 0 0" );
-	make_clip("_ladderqol_smootherm", "Everyone", 1, "-7 -255 0", "7 118 2", "-6060 -2586 427", "-45 0 0" );
-	make_clip("_ladderqol_smootherr", "Everyone", 1, "-7 -36 0", "7 77 2", "-6056 -2960 412", "-45 0 0" );
+	make_clip( "_ladderqol_smootherl", "Everyone", 1, "-7 -190 0", "7 190 2", "-6059 -2238 430", "-45 0 0" );
+	make_clip( "_ladderqol_smootherm", "Everyone", 1, "-7 -255 0", "7 118 2", "-6060 -2586 427", "-45 0 0" );
+	make_clip( "_ladderqol_smootherr", "Everyone", 1, "-7 -36 0", "7 77 2", "-6056 -2960 412", "-45 0 0" );
 	make_clip( "_whitakercurb_smoother1", "Everyone", 1, "-9 -315 0", "15 294 6", "-5525 -2349 448" );
 	make_clip( "_whitakercurb_smoother2", "Everyone", 1, "-9 -208 0", "15 160 6", "-5525 -1719 448" );
 	make_clip( "_booster_bridgestairsa", "Survivors", 1, "-4 -84 0", "4 84 700", "-5572 932 768" );
 	make_clip( "_booster_bridgestairsb", "Survivors", 1, "-56 -8 0", "56 8 700", "-5512 1016 832" );
 	make_clip( "_booster_building", "Survivors", 1, "-8 -384 0", "8 384 128", "-5064 1408 1344" );
 
-	if ( g_BaseMode == "versus" )
-	{
-		devchap( "BASE VERSUS" );
-
-		// FIXES
-
-		make_clip(	"_booster_mallroof",		"Survivors",	1,	"0 -130 -377",		"2150 136 448",		"-9218 -4415 1024" );
-
-	}
 	if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
@@ -102,11 +93,13 @@ function DoRoundFixes()
 		make_clip( "_ladderqol_railleftbot", "SI Players", 1, "-125 -1 0", "134 0 48", "-1154 2322 320" );
 		make_clip( "_ladderqol_raillefttop", "SI Players", 1, "-125 -1 0", "134 0 30", "-1154 2321 368" );
 		make_clip( "_skybridgebus_clip", "SI Players", 1, "-30 -95 -20", "20 48 45", "-5164 -485 595" );
-		make_clip( "_sneaky_hunter", "SI Players", 1, "-25 -142 0", "55 114 448", "-9207 -4402 1024" );
+		make_clip( "_clipgap_mallroof", "Everyone", 1, "-25 -142 0", "55 114 448", "-9207 -4402 1024" );
 		make_clip( "_yeswaychoke_clip", "SI Players", 1, "-275 -12 0", "251 240 945", "-3636 1800 523" );
 		make_clip( "_yeswaycorner_clip", "SI Players", 1, "-8 -512 0", "8 256 1472", "3703 2048 704" );
 		make_clip( "_yeswayturnpike_clipa", "SI Players", 1, "-128 -512 0", "128 512 768", "-384 512 704" );
 		make_clip( "_yeswayturnpike_clipb", "SI Players", 1, "-620 -8 -64", "620 8 1016", "-876 48 456" );
+		make_clip( "_booster_mallcanopy_a", "Survivors", 1, "-594 -132 -396", "594 132 396", "-7670 -4412 1076" );
+		make_clip( "_booster_mallcanopy_b", "Survivors", 1, "-174 -168 -404", "174 168 404", "-8000 -4400 1068" );
 		make_ladder( "_ladder_acbuildfront_cloned_acbuildside", "-6524 510 576", "-5059 7184 0", "0 90 0", "1 0 0" );
 		make_ladder( "_ladder_copfenceright_cloned_copfenceleft", "-1002 2368 391.5", "8 450 0" );
 		make_ladder( "_ladder_copvines_cloned_startvines", "2136 4926 600", "-2420 -1725 -35" );

--- a/root/scripts/vscripts/community/maps/c2m4_barns.nut
+++ b/root/scripts/vscripts/community/maps/c2m4_barns.nut
@@ -25,7 +25,6 @@ function DoRoundFixes()
 	make_clip( "_booster_barnbeam7", "Survivors", 1, "-145 -3 0", "158 5 65", "-614 -129 32" );
 	make_clip( "_booster_barnbeam8", "Survivors", 1, "-145 -3 0", "158 5 65", "-614 -321 32" );
 	make_clip( "_nav_eventfenceback", "Survivors", 1, "-8 -159 0", "25 164 1036", "-2266 807 -12", "0 72 0" );
-	make_clip( "_booster_clipextend", "Survivors", 1, "-38 -67 0", "10 61 668", "646 1995 356" );
 	make_clip( "_cliprework_finalfence", "Survivors", 1, "-96 -6 0", "120 11 704", "-120 2446 320" );
 	make_clip( "_booster_lightpole1", "Survivors", 1, "-59 -20 0", "64 18 637", "280 2077 387" );
 	make_clip( "_booster_lightpole2", "Survivors", 1, "-20 -59 0", "18 64 637", "1 1508 387" );
@@ -70,9 +69,9 @@ function DoRoundFixes()
 		// FIXES
 
 		make_clip( "_eventskip_fencehang", "Survivors", 1, "-6 -50 0", "6 50 1072", "398 1990 -48" );
-
 		make_clip( "_nav_eventfencea", "Survivors", 1, "-49 -3 0", "48 14 1045", "-2751 749 -21" );
 		make_clip( "_nav_eventfenceb", "Survivors", 1, "-49 -3 0", "48 14 1045", "-2499 749 -21" );
+		make_clip( "_booster_clipextend", "Survivors", 1, "-38 -67 0", "10 61 668", "646 1995 356" );
 
 		make_clip( "_ladder_askewhedgeshared_clip", "SI Players and AI", 1, "-3 -279 -7", "3 245 79", "593 1177 -63" );
 		make_ladder( "_ladder_askewhedgebotr1_cloned_askewhedgebotl", "610 1209.88 -123.984", "0 26 0" );

--- a/root/scripts/vscripts/community/maps/c3m1_plankcountry.nut
+++ b/root/scripts/vscripts/community/maps/c3m1_plankcountry.nut
@@ -13,10 +13,13 @@ PrecacheModel( "models/props_urban/fence_cover001_64.mdl" );
 
 function DoRoundFixes()
 {
-	make_clip(	"_hedge_behindtrains",		"Survivors",	1,	"-532 -120 0",		"800 58 701",		"-11078 8237 320" );
-	make_clip(	"_commonhop_crossing",		"Survivors",	1,	"-99 -260 0",		"99 426 691",		"-1025 4859 332" );
-	make_clip(	"_clipgap_fence",		"Survivors",	1,	"-4 -124 -155",		"4 124 155",		"-11084 7220 428" );
-	make_clip(	"_permstuck_coolingtank",	"Everyone",	1,	"-62 -58 -56",		"21 21 56",		"-10754 8610 216" );
+	make_clip( "_hedge_behindtrains_a",	"Survivors",	1,	"-56 -520 -356",		"56 520 356",		"-10713 7656 668" );
+	make_clip( "_hedge_behindtrains_b",	"Survivors",	1,	"-431 -75 -356",		"431 75 356",		"-10237 8186 668" );
+	make_clip( "_hedge_behindtrains_c",	"Survivors",	1,	"-50.5 -174 -362",		"50.5 174 362",		"-9756.5 8114 662" );
+	make_clip( "_hedge_behindtrains_d",	"Survivors",	1,	"-41 -394 -362",		"41 394 362",		"-9767 7546 662" );
+	make_clip( "_commonhop_crossing",		"Survivors",	1,	"-99 -260 0",		"99 426 691",		"-1025 4859 332" );
+	make_clip( "_clipgap_fence",		"Survivors",	1,	"-4 -68 -376",		"4 68 376",		"-11100 7188 648" );
+	make_clip( "_permstuck_coolingtank",	"Everyone",	1,	"-62 -58 -56",		"21 21 56",		"-10754 8610 216" );
 	make_clip( "_commonhop_coolingtank", "Survivors", 1, "-74 -236 0", "70 156 880", "-6806 7572 144" );
 	make_clip( "_booster_treetop", "Survivors", 1, "-108 -186 0", "108 174 717", "-5696 7348 247" );
 	make_clip( "_chargerassist_trainwheel", "Survivors", 1, "-133 -444 -130", "28 131 765", "-12379 8416 259", "0 -19 0" );

--- a/root/scripts/vscripts/community/maps/c6m2_bedlam.nut
+++ b/root/scripts/vscripts/community/maps/c6m2_bedlam.nut
@@ -25,8 +25,8 @@ function DoRoundFixes()
 	make_clip( "_ghostgrief_noio_gate2", "Everyone", 1, "-3 -39 0", "3 39 32", "5187 5445 -950" );
 	make_clip( "_booster_electricalbox", "Survivors", 1, "-28 -5 -20", "32 5 836", "917 3163 -4" );
 	make_clip( "_booster_acunit", "Survivors", 1, "-64 -32 0", "64 32 721", "743 3135 111" );
-	make_clip( "_dispsteps_smoother1", "Everyone", 1, "-95 -104 -4", "150 104 4", "2553 -936 -186", "34 0 0" );
-	make_clip( "_dispsteps_smoother2", "Everyone", 1, "-95 -104 -4", "135 104 4", "2201 -936 -58", "34 0 0" );
+	make_clip( "_dispsteps_smoother1", "Everyone", 1, "-95 -104 -4", "150 104 4", "2553 -936 -185", "34 0 0" );
+	make_clip( "_dispsteps_smoother2", "Everyone", 1, "-95 -104 -4", "135 104 4", "2201 -936 -57", "34 0 0" );
 	make_clip( "_plankescape_smoother", "Everyone", 1, "-82 -30 0", "143 31 8", "190 2976 120", "45 0 0" );
 	make_clip( "_permstuck_orangefence", "Everyone", 1, "-32 -32 0", "32 32 64", "2188 1856 -64" );
 	make_clip( "_booster_awningnlights", "Survivors", 1, "-124 -41 0", "129 56 762", "1264 3705 8" );

--- a/root/scripts/vscripts/community/maps/c6m2_bedlam.nut
+++ b/root/scripts/vscripts/community/maps/c6m2_bedlam.nut
@@ -25,8 +25,8 @@ function DoRoundFixes()
 	make_clip( "_ghostgrief_noio_gate2", "Everyone", 1, "-3 -39 0", "3 39 32", "5187 5445 -950" );
 	make_clip( "_booster_electricalbox", "Survivors", 1, "-28 -5 -20", "32 5 836", "917 3163 -4" );
 	make_clip( "_booster_acunit", "Survivors", 1, "-64 -32 0", "64 32 721", "743 3135 111" );
-	make_clip( "_dispsteps_smoother1", "Everyone", 1, "-95 -104 -4", "150 104 4", "2553 -936 -186", "33.5 0 0" );
-	make_clip( "_dispsteps_smoother2", "Everyone", 1, "-95 -104 -4", "135 104 4", "2201 -936 -58", "33.5 0 0" );
+	make_clip( "_dispsteps_smoother1", "Everyone", 1, "-95 -104 -4", "150 104 4", "2553 -936 -186", "34 0 0" );
+	make_clip( "_dispsteps_smoother2", "Everyone", 1, "-95 -104 -4", "135 104 4", "2201 -936 -58", "34 0 0" );
 	make_clip( "_plankescape_smoother", "Everyone", 1, "-82 -30 0", "143 31 8", "190 2976 120", "45 0 0" );
 	make_clip( "_permstuck_orangefence", "Everyone", 1, "-32 -32 0", "32 32 64", "2188 1856 -64" );
 	make_clip( "_booster_awningnlights", "Survivors", 1, "-124 -41 0", "129 56 762", "1264 3705 8" );


### PR DESCRIPTION
c1m2: Improved clip: `_booster_mallroof`, converted `_sneaky_hunter` to an "everyone" clip, renamed to `_clipgap_mallroof` (PVP modes)
c2m4: Moved `_booster_clipextend` to survival only, this clip was being spawned in all modes when it was only relevant to survival (all modes)
c3m1: Improved clip: `_clipgap_fence` (all modes)
c3m1: Fixed #5 and improved clip: `_hedge_behindtrains` (all modes)
c6m2: Fixed collision issue with clips on the stairs by the saferoom that caused noticeable teleporting when not on a local server (all modes)
c10m3: Fixed an infected perma-stuck spot on the barricade by the church (PVP modes)
c14m2: Fixed a perma-stuck spot between a fence and tree cluster at the cliff overlooking the beach (versus only)