### PR TITLE
Optimize gamemodes.txt

### DIFF
--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -576,10 +576,6 @@
 			"z_spitter_health" 300
 			"z_charger_allow_shove" 1
 			"director_no_mobs" 1
-			"z_special_spawn_interval" 10
-			"director_special_respawn_interval" 10
-			"director_special_initial_spawn_delay_min" 10
-			"director_special_initial_spawn_delay_max" 30
 			"sv_disable_glow_survivors" 1
 			"sv_disable_glow_faritems" 1
 			"intensity_decay_time" 15

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -506,7 +506,6 @@
 		"achievementindex"	"5"
 		"x360ctx"	"33"
 		"dlcmask"	"0x0000000000000002"
-		"hasdifficulty"		"1"
 		"builtin"	"1"
 		"Author"	"SR69MMJC and Karma Jockey"
 		"Image"		"vgui/blog/flu_season"
@@ -619,8 +618,6 @@
 		"builtin"	"1"
 		"Author"	"Rayman1103"
 		"Image"		"vgui/blog/deaths_door"
-		
-		"hasdifficulty"		"1"
 	}
 
 	"community6"

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -511,7 +511,6 @@
 		convar
 		{
 			"sb_max_team_melee_weapons" 1
-			"ai_talk_idle_enabled" 1
 			"sb_vomit_blind_time" 0.1
 			"boomer_vomit_delay" 0.1
 			"z_vomit_fade_duration" 0.1
@@ -590,12 +589,12 @@
 			"director_molotov_density" 7.48
 			"director_pistol_density" 6
 			"fog_override" 1
-			"fog_enable" 1
+			"fog_enable" 1	// to enforce default
 			"fog_start" 242
 			"fog_end" 730
 			"fog_startskybox" -10000
 			"fog_endskybox" -10000
-			"fog_enableskybox" 1
+			"fog_enableskybox" 1	// to enforce default
 			"z_tank_health" 5000
 			"z_tank_throw_force" 1200
 			"z_tank_throw_health" 200

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -1,0 +1,716 @@
+"GameModes"
+{
+	"coop"
+	{
+		"base"		"coop"
+		"maxplayers"	"4"
+		
+		"x360ctx"	"0"
+		"x360matchrule"		"0"
+		"x360presence"		"5"
+		"x360presence:"
+		{
+			"network:offline"	"11"
+			"play:commentary"	"3"
+			"play:credits"		"2"
+		}
+
+		"hasdifficulty"		"1"
+	}
+
+	"realism"
+	{
+		"base"		"realism"
+		"maxplayers"    "4"	// realism
+		"x360ctx"	"6"
+		"x360matchrule"		"0"
+		"x360presence"		"5"
+
+		"hasdifficulty"		"1"
+
+		// set base gamemode convars first, then the current gamemode
+		convar
+		{
+			sv_disable_glow_survivors 1
+			sv_disable_glow_faritems 1
+			sv_rescue_disabled 1
+			z_non_head_damage_factor_multiplier 0.5
+			z_head_damage_causes_wounds 1
+			z_use_next_difficulty_damage_factor 1
+			z_witch_always_kills 1
+		}
+
+	}
+
+	"survival"
+	{
+		"base"		"survival"
+		"maxplayers"    "4"	// survival
+		"x360ctx"	"3"
+		"x360matchrule"		"2"
+		"x360matchruleteam"	"3"
+		"x360presence"		"9"
+
+		"singlechapter"		"1"
+
+		convar
+		{
+			"director_convert_pills" 0
+		}
+	}
+
+	"versus"
+	{
+		"base"		"versus"
+		"maxplayers"    "8"	// versus
+		"x360ctx"	"1"
+		"x360matchrule"		"1"
+		"x360matchruleteam"	"3"
+		"x360presence"		"7"
+
+		"playercontrolledzombies"	"1"
+
+		convar
+		{
+			"z_scrimmage_creep_delay" 0
+			"z_scrimmage_creep_rate" 100
+			"z_spawn_safety_range" 200
+			"tongue_miss_delay" 3
+			"tongue_hit_delay" 15
+			"tongue_dropping_to_ground_time" 0.5
+			"tongue_los_forgiveness_time" 1.5
+			"tongue_no_progress_choke_early_delay" 1.0
+			"z_pounce_stumble_radius" 160
+			"z_pounce_damage_interrupt" 150
+			"z_hunter_limit" 2
+			"z_smoker_limit" 2
+			"z_max_stagger_duration" 0.9
+			"sv_alltalk" 0
+			"z_ghost_los_expected_progress" 2000
+			"tongue_choke_damage_amount" 5
+			"tongue_break_from_damage_amount" 300
+			"director_special_initial_spawn_delay_min" 2
+			"director_special_initial_spawn_delay_max" 10
+			"sv_infected_ceda_vomitjar_probability" 0
+			"versus_tank_flow_team_variation" 0
+			"z_ghost_delay_max" 24
+			"vomitjar_duration_infected_pz" 15
+			"z_leap_interval_post_incap" 25
+			"z_frustration_spawn_delay" 15
+			"z_jockey_ride_damage" 2
+			"z_jockey_ride_damage_interval" 0.5
+			"tank_burn_duration" 90
+			"z_witch_damage_per_kill_hit" 15
+			
+			// these are 360 only convar changes, if you prefix with 360_, they'll
+			// get set on 360 and dedicated for 360
+			"360_z_mega_mob_size" 25
+			"360_z_mob_spawn_max_size" 18
+			"360_z_versus_wandering_density" 0.026
+		}
+	}
+
+	"scavenge"
+	{
+		"base"		"scavenge"
+		"maxplayers"    "8"	// scavenge
+		"x360ctx"	"4"
+		"x360matchrule"		"4"
+		"x360matchruleteam"	"5"
+		"x360presence"		"9"
+
+		"singlechapter"		"1"
+		"hasroundlimit"		"1"
+
+		"playercontrolledzombies"	"1"
+
+		convar
+		{
+			"z_scrimmage_creep_delay" 0
+			"z_scrimmage_creep_rate" 100
+			"z_spawn_safety_range" 200
+			"tongue_miss_delay" 3
+			"tongue_hit_delay" 15
+			"tongue_dropping_to_ground_time" 0.5
+			"tongue_los_forgiveness_time" 1.5
+			"tongue_no_progress_choke_early_delay" 1.0
+			"z_pounce_stumble_radius" 160
+			"z_pounce_damage_interrupt" 150
+			"z_hunter_limit" 2
+			"z_smoker_limit" 2
+			"z_max_stagger_duration" 0.9
+			"sv_alltalk" 0
+			"z_ghost_los_expected_progress" 2000
+			"tongue_choke_damage_amount" 5
+			"tongue_break_from_damage_amount" 300
+			"director_special_initial_spawn_delay_min" 2
+			"director_special_initial_spawn_delay_max" 10
+			"z_jockey_ride_damage" 2
+			"z_jockey_ride_damage_interval" 0.5
+
+			// these are 360 only convar changes, if you prefix with 360_, they'll
+			// get set on 360 and dedicated for 360
+			"360_z_mega_mob_size" 25
+			"360_z_mob_spawn_max_size" 18
+			"360_z_versus_wandering_density" 0.026
+		}
+	}
+
+	"mutation1"
+	{
+		"base"		"coop"
+		"maxplayers"    "1"
+		"achievementindex"	"0"
+		"x360ctx"	"7"
+		"x360presence" 	"13"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/last_man_on_earth"
+
+		convar
+		{
+			z_jockey_ride_damage 15
+			z_pounce_damage 10
+			tongue_choke_damage_amount 15
+			tongue_drag_damage_amount 15
+		}
+	}
+
+	"mutation2"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"1"
+		"x360ctx"	"8"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/headshot"
+	}
+
+	"mutation3"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"2"
+		"x360ctx"	"9"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/bleed_out"
+
+		convar
+		{
+			pain_pills_decay_rate 0.27
+		}
+	}
+
+	"mutation4"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"3"
+		"x360ctx"	"10"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/hard_eight"
+	}
+
+	"mutation5"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"4"
+		"x360ctx"	"11"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/four_swordsmen"
+
+		convar
+		{ 
+			sb_melee_approach_victim 1
+			sv_infected_police_tonfa_probability 0
+			sv_infected_riot_control_tonfa_probability 0
+		}
+	}
+
+	"mutation7"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"6"
+		"x360ctx"	"13"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/chainsaw_massacre"
+
+		convar
+		{ 
+			sb_melee_approach_victim 1
+			sv_infected_police_tonfa_probability 0
+			sv_infected_riot_control_tonfa_probability 0
+		}
+	}
+
+	"mutation8"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"7"
+		"x360ctx"	"14"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/iron_man"
+
+		convar
+		{
+			sv_permawipe 1
+			sv_disable_glow_survivors 1
+			sv_disable_glow_faritems 1
+			sv_rescue_disabled 1
+			z_non_head_damage_factor_multiplier 0.5
+			z_head_damage_causes_wounds 1
+			z_use_next_difficulty_damage_factor 1
+			z_witch_always_kills 1
+		}
+	}
+
+	"mutation9"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"8"
+		"x360ctx"	"15"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/gnome"
+	}
+
+	"mutation10"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"9"
+		"x360ctx"	"16"
+		"x360presence"	"5"
+		"x360presence:"
+		{
+			"state:game"	"10"
+		}
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/first_survivor_out"
+	}
+
+	"mutation11"
+	{
+		"base"		"versus"
+		"maxplayers"    "8"
+		"achievementindex"	"10"
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"18"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/healthpackalypse"
+
+		convar
+		{
+			"director_special_initial_spawn_delay_min" 2
+			"director_special_initial_spawn_delay_max" 10
+		}
+	}
+
+	"mutation12"
+	{
+		"base"		"versus"
+		"maxplayers"    "8"
+		"achievementindex"	"13"	// intentionally mis-numbered
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"20"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"hidden"	"1"
+
+		convar
+		{
+			sv_disable_glow_survivors 1
+			sv_disable_glow_faritems 1
+			sv_rescue_disabled 1
+			z_non_head_damage_factor_multiplier 0.5
+			z_head_damage_causes_wounds 1
+			z_use_next_difficulty_damage_factor 1
+			z_witch_always_kills 1
+			"director_special_initial_spawn_delay_min" 2
+			"director_special_initial_spawn_delay_max" 10
+		}
+
+	}
+
+	"mutation13"
+	{
+		"base"		"scavenge"
+		"maxplayers"    "8"
+		"achievementindex"	"12"
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"22"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/follow_the_liter"
+
+		convar
+		{
+			"director_special_initial_spawn_delay_min" 2
+			"director_special_initial_spawn_delay_max" 10
+		}
+	}
+
+	"mutation14"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"11"	// intentionally mis-numbered
+		"x360ctx"	"24"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/gib_fest"
+
+		convar
+		{
+			"sv_infinite_primary_ammo" 1
+			sv_infected_police_tonfa_probability 0
+			sv_infected_riot_control_tonfa_probability 0
+		}
+	}
+
+	"mutation15"
+	{
+		"base"		"survival"
+		"maxplayers"    "8"
+		"achievementindex"	"14"
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"28"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"hidden"	"1"
+
+		convar
+		{
+			"z_scrimmage_creep_delay" 0
+			"z_scrimmage_creep_rate" 100
+			"z_spawn_safety_range" 200
+			"tongue_miss_delay" 3
+			"tongue_hit_delay" 15
+			"tongue_dropping_to_ground_time" 0.5
+			"tongue_los_forgiveness_time" 1.5
+			"tongue_no_progress_choke_early_delay" 1.0
+			"z_pounce_stumble_radius" 160
+			"z_pounce_damage_interrupt" 150
+			"z_hunter_limit" 2
+			"z_smoker_limit" 2
+			"z_max_stagger_duration" 0.9
+			"sv_alltalk" 0
+			"z_ghost_los_expected_progress" 2000
+			"tongue_choke_damage_amount" 5
+			"tongue_break_from_damage_amount" 300
+			"director_special_initial_spawn_delay_min" 2
+			"director_special_initial_spawn_delay_max" 10
+			"z_jockey_ride_damage" 2
+			"z_jockey_ride_damage_interval" 0.5
+		}
+	}
+
+	"mutation16"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"15"
+		"x360ctx"	"25"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/hunting_party"
+	}
+
+	"mutation17"
+	{
+		"base"		"coop"
+		"maxplayers"    "1"
+		"achievementindex"	"16"
+		"x360ctx"	"17"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/lone_gunman"
+
+		convar
+		{
+			sv_infected_police_tonfa_probability 0
+			sv_infected_riot_control_tonfa_probability 0
+		}
+	}
+
+	"mutation18"
+	{
+		"base"		"versus"
+		"maxplayers"    "8"
+		"achievementindex"	"17"
+		"x360ctx"	"26"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/bleed_out_versus"
+
+		"playercontrolledzombies"	"1"
+
+		convar
+		{
+			pain_pills_decay_rate 0.27
+		}
+	}
+
+	"mutation19"
+	{
+		"base"		"versus"
+		"maxplayers"    "8"
+		"achievementindex"	"18"
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"30"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/tank_tank_tank"
+		
+		convar
+		{
+			"z_spawn_safety_range" 600
+			"z_ghost_travel_distance" 2000
+			"z_tank_health" 2000
+			"z_frustration" 0
+		}		
+	}
+
+	"mutation20"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"19"
+		"x360ctx"	"31"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Valve"
+		"Image"		"vgui/blog/healing_gnome"
+	}
+
+	"community1" // special delivery
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"5"
+		"x360ctx"	"32"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Rayman1103"
+		"Image"		"vgui/blog/special_delivery"
+
+		convar
+		{
+			hud_deathnotice_threats 1
+			z_female_boomer_spawn_chance 50
+		}
+	}
+
+	"community2"
+	{
+
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"5"
+		"x360ctx"	"33"
+		"dlcmask"	"0x0000000000000002"
+		"hasdifficulty"		"1"
+		"builtin"	"1"
+		"Author"	"SR69MMJC and Karma Jockey"
+		"Image"		"vgui/blog/flu_season"
+
+		convar
+		{
+			"sb_max_team_melee_weapons" 1
+			"ai_talk_idle_enabled" 1
+			"sb_vomit_blind_time" 0.1
+			"boomer_vomit_delay" 0.1
+			"z_vomit_fade_duration" 0.1
+			"z_vomit_fade_start" 0.1
+			"z_vomit_duration" 1
+			"z_vomit_interval" 0.1
+			"z_vomit_fatigue" 0.1
+			"z_vomit_range" 150
+			"z_exploding_splat_radius" 1
+			"z_exploding_health" 100
+			"z_exploding_speed" 350
+			"z_exploding_shove_max" 99
+			"z_exploding_shove_min" 99
+			"boomer_exposed_time_tolerance" 0.1
+			"boomer_pz_claw_dmg" 15
+			"z_wandering_density" 0
+			"z_scout_mob_spawn_range" 1000
+			"director_no_mobs" 1
+			"z_health" 100	
+			"z_spawn_mobs_behind_chance" 0
+		}
+	}
+
+	"community3"
+	{
+		"base"		"versus"
+		"maxplayers"	"8"
+		"achievementindex"	"5"
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"34"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Winded"
+		"Image"		"vgui/blog/riding_my_survivor"
+
+		convar
+		{
+			z_jockey_health 500
+			z_jockey_speed 450
+			z_jockey_ride_damage 10
+                	z_jockey_ride_damage_delay 1.0
+                	z_jockey_ride_damage_interval 1.0
+		}
+	}
+
+	"community4"
+	{
+		"base"		"survival"
+		"maxplayers"    "4"
+		"achievementindex"	"5"
+		"x360ctx"	"35"
+		"dlcmask"	"0x0000000000000002"
+		"hasdifficulty"		"1"
+		"builtin"	"1"
+		"Author"	"Karma Jockey"
+		"Image"		"vgui/blog/nightmare"
+
+		convar
+		{
+			"z_hunter_health" 300
+			"z_charger_health" 300
+			"z_spitter_health" 300
+			"z_charger_allow_shove" 1
+			"director_no_mobs" 1
+			"z_special_spawn_interval" 10
+			"director_special_respawn_interval" 10
+			"director_special_initial_spawn_delay_min" 10
+			"director_special_initial_spawn_delay_max" 30
+			"sv_disable_glow_survivors" 1
+			"sv_disable_glow_faritems" 1
+			"intensity_decay_time" 15
+			"director_relax_max_interval" 20
+			"director_relax_min_interval" 10
+			"first_aid_heal_percent" 0.9
+			"pain_pills_health_value" 65
+			"pain_pills_decay_rate" 0.21
+			"director_scavenge_item_override" 1
+			"director_pain_pill_density" 7.48
+			"director_pipe_bomb_density" 7.48
+			"director_molotov_density" 7.48
+			"director_pistol_density" 6
+			"fog_override" 1
+			"fog_enable" 1
+			"fog_start" 242
+			"fog_end" 730
+			"fog_startskybox" -10000
+			"fog_endskybox" -10000
+			"fog_enableskybox" 1
+			"z_tank_health" 5000
+			"z_tank_throw_force" 1200
+			"z_tank_throw_health" 200
+		}
+	}
+
+	"community5"
+	{
+		"base"		"coop"
+		"maxplayers"    "4"
+		"achievementindex"	"5"
+		"x360ctx"	"36"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"Rayman1103"
+		"Image"		"vgui/blog/deaths_door"
+		
+		"hasdifficulty"		"1"
+		convar
+		{
+			"survivor_max_incapacitated_count" 0
+		}
+	}
+
+	"community6"
+	{
+		"base"		"versus"
+		"maxplayers"	"8"
+		"achievementindex"	"5"
+		"playercontrolledzombies"	"1"
+		"x360ctx"	"37"
+		"dlcmask"	"0x0000000000000002"
+		"builtin"	"1"
+		"Author"	"ProdigySim"
+		"Image"		"vgui/blog/confogl"
+
+		convar
+		{
+			"sv_infected_ceda_vomitjar_probability" 0
+			"sv_infected_police_tonfa_probability" 0
+			"sv_infected_riot_control_tonfa_probability" 0
+			"z_fallen_max_count" 0
+			"gascan_spit_time" 2
+			"z_mob_spawn_min_size" 25
+			"z_mob_spawn_max_size" 25
+ 			"z_mob_spawn_min_interval_normal" 999999
+			"z_mob_spawn_max_interval_normal" 999999
+			"ammo_shotgun_max" 80
+			"ammo_huntingrifle_max" 220
+			"sv_force_time_of_day" 0
+			"z_ghost_delay_min" 20
+			"z_ghost_delay_max" 20
+			"director_vs_convert_pills" 0
+			"director_convert_pills" 0
+			"director_convert_pills_critical_health" 0
+			"director_convert_pills_to_defib_health" 0
+			"versus_tank_chance" 1
+			"versus_tank_chance_finale" 1
+			"versus_tank_chance_intro" 1
+			"versus_tank_flow_team_variation" 0
+			"versus_witch_chance" 0.75
+			"versus_witch_chance_finale" 0
+			"versus_witch_chance_intro" 0
+			"versus_boss_flow_max" 0.9
+			"versus_boss_flow_max_intro" 0.9
+			"versus_boss_flow_min" 0.15
+ 			"versus_boss_flow_min_intro" 0.15
+			"z_witch_damage_per_kill_hit" 75
+			"z_witch_personal_space" 240
+			"z_leap_interval_post_incap" 15
+			"z_jockey_control_variance" 0.15
+			"z_finale_spawn_safety_range" 150
+			"z_gun_swing_vs_min_penalty" 1
+
+			// Mega mob size should be intact for 360. (25)
+			"360_z_mob_spawn_min_size" 18
+			"360_z_mob_spawn_max_size" 18
+		}
+	}
+}

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -4,7 +4,7 @@
 	{
 		"base"		"coop"
 		"maxplayers"	"4"
-		
+
 		"x360ctx"	"0"
 		"x360matchrule"		"0"
 		"x360presence"		"5"
@@ -21,7 +21,7 @@
 	"realism"
 	{
 		"base"		"realism"
-		"maxplayers"    "4"	// realism
+		"maxplayers"	"4"
 		"x360ctx"	"6"
 		"x360matchrule"		"0"
 		"x360presence"		"5"
@@ -39,13 +39,12 @@
 			z_use_next_difficulty_damage_factor 1
 			z_witch_always_kills 1
 		}
-
 	}
 
 	"survival"
 	{
 		"base"		"survival"
-		"maxplayers"    "4"	// survival
+		"maxplayers"	"4"
 		"x360ctx"	"3"
 		"x360matchrule"		"2"
 		"x360matchruleteam"	"3"
@@ -62,7 +61,7 @@
 	"versus"
 	{
 		"base"		"versus"
-		"maxplayers"    "8"	// versus
+		"maxplayers"	"8"
 		"x360ctx"	"1"
 		"x360matchrule"		"1"
 		"x360matchruleteam"	"3"
@@ -101,7 +100,7 @@
 			"z_jockey_ride_damage_interval" 0.5
 			"tank_burn_duration" 90
 			"z_witch_damage_per_kill_hit" 15
-			
+
 			// these are 360 only convar changes, if you prefix with 360_, they'll
 			// get set on 360 and dedicated for 360
 			"360_z_mega_mob_size" 25
@@ -113,7 +112,7 @@
 	"scavenge"
 	{
 		"base"		"scavenge"
-		"maxplayers"    "8"	// scavenge
+		"maxplayers"	"8"
 		"x360ctx"	"4"
 		"x360matchrule"		"4"
 		"x360matchruleteam"	"5"
@@ -159,7 +158,7 @@
 	"mutation1"
 	{
 		"base"		"coop"
-		"maxplayers"    "1"
+		"maxplayers"	"1"
 		"achievementindex"	"0"
 		"x360ctx"	"7"
 		"x360presence" 	"13"
@@ -180,7 +179,7 @@
 	"mutation2"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"1"
 		"x360ctx"	"8"
 		"dlcmask"	"0x0000000000000002"
@@ -192,7 +191,7 @@
 	"mutation3"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"2"
 		"x360ctx"	"9"
 		"dlcmask"	"0x0000000000000002"
@@ -204,7 +203,7 @@
 	"mutation4"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"3"
 		"x360ctx"	"10"
 		"dlcmask"	"0x0000000000000002"
@@ -216,7 +215,7 @@
 	"mutation5"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"4"
 		"x360ctx"	"11"
 		"dlcmask"	"0x0000000000000002"
@@ -225,7 +224,7 @@
 		"Image"		"vgui/blog/four_swordsmen"
 
 		convar
-		{ 
+		{
 			sb_melee_approach_victim 1
 			sv_infected_police_tonfa_probability 0
 			sv_infected_riot_control_tonfa_probability 0
@@ -235,7 +234,7 @@
 	"mutation7"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"6"
 		"x360ctx"	"13"
 		"dlcmask"	"0x0000000000000002"
@@ -244,7 +243,7 @@
 		"Image"		"vgui/blog/chainsaw_massacre"
 
 		convar
-		{ 
+		{
 			sb_melee_approach_victim 1
 			sv_infected_police_tonfa_probability 0
 			sv_infected_riot_control_tonfa_probability 0
@@ -254,7 +253,7 @@
 	"mutation8"
 	{
 		"base"		"realism"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"7"
 		"x360ctx"	"14"
 		"dlcmask"	"0x0000000000000002"
@@ -271,7 +270,7 @@
 	"mutation9"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"8"
 		"x360ctx"	"15"
 		"dlcmask"	"0x0000000000000002"
@@ -283,7 +282,7 @@
 	"mutation10"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"9"
 		"x360ctx"	"16"
 		"x360presence"	"5"
@@ -300,7 +299,7 @@
 	"mutation11"
 	{
 		"base"		"versus"
-		"maxplayers"    "8"
+		"maxplayers"	"8"
 		"achievementindex"	"10"
 		"playercontrolledzombies"	"1"
 		"x360ctx"	"18"
@@ -313,7 +312,7 @@
 	"mutation12"
 	{
 		"base"		"versus"
-		"maxplayers"    "8"
+		"maxplayers"	"8"
 		"achievementindex"	"13"	// intentionally mis-numbered
 		"playercontrolledzombies"	"1"
 		"x360ctx"	"20"
@@ -331,13 +330,12 @@
 			z_use_next_difficulty_damage_factor 1
 			z_witch_always_kills 1
 		}
-
 	}
 
 	"mutation13"
 	{
 		"base"		"scavenge"
-		"maxplayers"    "8"
+		"maxplayers"	"8"
 		"achievementindex"	"12"
 		"playercontrolledzombies"	"1"
 		"x360ctx"	"22"
@@ -350,7 +348,7 @@
 	"mutation14"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"11"	// intentionally mis-numbered
 		"x360ctx"	"24"
 		"dlcmask"	"0x0000000000000002"
@@ -369,7 +367,7 @@
 	"mutation15"
 	{
 		"base"		"survival"
-		"maxplayers"    "8"
+		"maxplayers"	"8"
 		"achievementindex"	"14"
 		"playercontrolledzombies"	"1"
 		"x360ctx"	"28"
@@ -406,7 +404,7 @@
 	"mutation16"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"15"
 		"x360ctx"	"25"
 		"dlcmask"	"0x0000000000000002"
@@ -418,7 +416,7 @@
 	"mutation17"
 	{
 		"base"		"coop"
-		"maxplayers"    "1"
+		"maxplayers"	"1"
 		"achievementindex"	"16"
 		"x360ctx"	"17"
 		"dlcmask"	"0x0000000000000002"
@@ -436,7 +434,7 @@
 	"mutation18"
 	{
 		"base"		"versus"
-		"maxplayers"    "8"
+		"maxplayers"	"8"
 		"achievementindex"	"17"
 		"x360ctx"	"26"
 		"dlcmask"	"0x0000000000000002"
@@ -450,7 +448,7 @@
 	"mutation19"
 	{
 		"base"		"versus"
-		"maxplayers"    "8"
+		"maxplayers"	"8"
 		"achievementindex"	"18"
 		"playercontrolledzombies"	"1"
 		"x360ctx"	"30"
@@ -458,20 +456,20 @@
 		"builtin"	"1"
 		"Author"	"Valve"
 		"Image"		"vgui/blog/tank_tank_tank"
-		
+
 		convar
 		{
 			"z_spawn_safety_range" 600
 			"z_ghost_travel_distance" 2000
 			"z_tank_health" 2000
 			"z_frustration" 0
-		}		
+		}
 	}
 
 	"mutation20"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"19"
 		"x360ctx"	"31"
 		"dlcmask"	"0x0000000000000002"
@@ -480,10 +478,10 @@
 		"Image"		"vgui/blog/healing_gnome"
 	}
 
-	"community1" // special delivery
+	"community1"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"5"
 		"x360ctx"	"32"
 		"dlcmask"	"0x0000000000000002"
@@ -502,7 +500,7 @@
 	{
 
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"5"
 		"x360ctx"	"33"
 		"dlcmask"	"0x0000000000000002"
@@ -532,7 +530,7 @@
 			"z_wandering_density" 0
 			"z_scout_mob_spawn_range" 1000
 			"director_no_mobs" 1
-			"z_health" 100	
+			"z_health" 100
 			"z_spawn_mobs_behind_chance" 0
 		}
 	}
@@ -554,15 +552,15 @@
 			z_jockey_health 500
 			z_jockey_speed 450
 			z_jockey_ride_damage 10
-                	z_jockey_ride_damage_delay 1.0
-                	z_jockey_ride_damage_interval 1.0
+			z_jockey_ride_damage_delay 1.0
+			z_jockey_ride_damage_interval 1.0
 		}
 	}
 
 	"community4"
 	{
 		"base"		"survival"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"5"
 		"x360ctx"	"35"
 		"dlcmask"	"0x0000000000000002"
@@ -611,7 +609,7 @@
 	"community5"
 	{
 		"base"		"coop"
-		"maxplayers"    "4"
+		"maxplayers"	"4"
 		"achievementindex"	"5"
 		"x360ctx"	"36"
 		"dlcmask"	"0x0000000000000002"

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -550,7 +550,6 @@
 			z_jockey_health 500
 			z_jockey_speed 450
 			z_jockey_ride_damage 10
-			z_jockey_ride_damage_delay 1.0
 			z_jockey_ride_damage_interval 1.0
 		}
 	}
@@ -626,7 +625,6 @@
 
 		convar
 		{
-			"sv_infected_ceda_vomitjar_probability" 0
 			"sv_infected_police_tonfa_probability" 0
 			"sv_infected_riot_control_tonfa_probability" 0
 			"z_fallen_max_count" 0
@@ -638,15 +636,12 @@
 			"ammo_shotgun_max" 80
 			"ammo_huntingrifle_max" 220
 			"sv_force_time_of_day" 0
-			"z_ghost_delay_min" 20
 			"z_ghost_delay_max" 20
 			"versus_tank_chance" 1
 			"versus_tank_chance_finale" 1
 			"versus_tank_chance_intro" 1
-			"versus_witch_chance" 0.75
 			"versus_witch_chance_finale" 0
 			"versus_witch_chance_intro" 0
-			"versus_boss_flow_max" 0.9
 			"versus_boss_flow_max_intro" 0.9
 			"versus_boss_flow_min" 0.15
 			"versus_boss_flow_min_intro" 0.15
@@ -659,7 +654,6 @@
 
 			// Mega mob size should be intact for 360. (25)
 			"360_z_mob_spawn_min_size" 18
-			"360_z_mob_spawn_max_size" 18
 		}
 	}
 }

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -106,7 +106,7 @@
 			// get set on 360 and dedicated for 360
 			"360_z_mega_mob_size" 25
 			"360_z_mob_spawn_max_size" 18
-			"360_z_versus_wandering_density" 0.026
+			"360_versus_wandering_zombie_density" 0.026
 		}
 	}
 
@@ -152,7 +152,7 @@
 			// get set on 360 and dedicated for 360
 			"360_z_mega_mob_size" 25
 			"360_z_mob_spawn_max_size" 18
-			"360_z_versus_wandering_density" 0.026
+			"360_versus_wandering_zombie_density" 0.026
 		}
 	}
 
@@ -199,11 +199,6 @@
 		"builtin"	"1"
 		"Author"	"Valve"
 		"Image"		"vgui/blog/bleed_out"
-
-		convar
-		{
-			pain_pills_decay_rate 0.27
-		}
 	}
 
 	"mutation4"
@@ -258,7 +253,7 @@
 
 	"mutation8"
 	{
-		"base"		"coop"
+		"base"		"realism"
 		"maxplayers"    "4"
 		"achievementindex"	"7"
 		"x360ctx"	"14"
@@ -270,13 +265,6 @@
 		convar
 		{
 			sv_permawipe 1
-			sv_disable_glow_survivors 1
-			sv_disable_glow_faritems 1
-			sv_rescue_disabled 1
-			z_non_head_damage_factor_multiplier 0.5
-			z_head_damage_causes_wounds 1
-			z_use_next_difficulty_damage_factor 1
-			z_witch_always_kills 1
 		}
 	}
 
@@ -320,12 +308,6 @@
 		"builtin"	"1"
 		"Author"	"Valve"
 		"Image"		"vgui/blog/healthpackalypse"
-
-		convar
-		{
-			"director_special_initial_spawn_delay_min" 2
-			"director_special_initial_spawn_delay_max" 10
-		}
 	}
 
 	"mutation12"
@@ -348,8 +330,6 @@
 			z_head_damage_causes_wounds 1
 			z_use_next_difficulty_damage_factor 1
 			z_witch_always_kills 1
-			"director_special_initial_spawn_delay_min" 2
-			"director_special_initial_spawn_delay_max" 10
 		}
 
 	}
@@ -365,12 +345,6 @@
 		"builtin"	"1"
 		"Author"	"Valve"
 		"Image"		"vgui/blog/follow_the_liter"
-
-		convar
-		{
-			"director_special_initial_spawn_delay_min" 2
-			"director_special_initial_spawn_delay_max" 10
-		}
 	}
 
 	"mutation14"
@@ -471,11 +445,6 @@
 		"Image"		"vgui/blog/bleed_out_versus"
 
 		"playercontrolledzombies"	"1"
-
-		convar
-		{
-			pain_pills_decay_rate 0.27
-		}
 	}
 
 	"mutation19"
@@ -652,10 +621,6 @@
 		"Image"		"vgui/blog/deaths_door"
 		
 		"hasdifficulty"		"1"
-		convar
-		{
-			"survivor_max_incapacitated_count" 0
-		}
 	}
 
 	"community6"
@@ -686,14 +651,9 @@
 			"sv_force_time_of_day" 0
 			"z_ghost_delay_min" 20
 			"z_ghost_delay_max" 20
-			"director_vs_convert_pills" 0
-			"director_convert_pills" 0
-			"director_convert_pills_critical_health" 0
-			"director_convert_pills_to_defib_health" 0
 			"versus_tank_chance" 1
 			"versus_tank_chance_finale" 1
 			"versus_tank_chance_intro" 1
-			"versus_tank_flow_team_variation" 0
 			"versus_witch_chance" 0.75
 			"versus_witch_chance_finale" 0
 			"versus_witch_chance_intro" 0

--- a/root/scripts/gamemodes.txt
+++ b/root/scripts/gamemodes.txt
@@ -161,7 +161,7 @@
 		"maxplayers"	"1"
 		"achievementindex"	"0"
 		"x360ctx"	"7"
-		"x360presence" 	"13"
+		"x360presence"	"13"
 		"dlcmask"	"0x0000000000000002"
 		"builtin"	"1"
 		"Author"	"Valve"
@@ -498,7 +498,6 @@
 
 	"community2"
 	{
-
 		"base"		"coop"
 		"maxplayers"	"4"
 		"achievementindex"	"5"
@@ -634,7 +633,7 @@
 			"gascan_spit_time" 2
 			"z_mob_spawn_min_size" 25
 			"z_mob_spawn_max_size" 25
- 			"z_mob_spawn_min_interval_normal" 999999
+			"z_mob_spawn_min_interval_normal" 999999
 			"z_mob_spawn_max_interval_normal" 999999
 			"ammo_shotgun_max" 80
 			"ammo_huntingrifle_max" 220
@@ -650,7 +649,7 @@
 			"versus_boss_flow_max" 0.9
 			"versus_boss_flow_max_intro" 0.9
 			"versus_boss_flow_min" 0.15
- 			"versus_boss_flow_min_intro" 0.15
+			"versus_boss_flow_min_intro" 0.15
 			"z_witch_damage_per_kill_hit" 75
 			"z_witch_personal_space" 240
 			"z_leap_interval_post_incap" 15


### PR DESCRIPTION
This PR aims to optimize **gamemodes.txt** mainly by cleaning up unnecessary cvars and optimizing the formatting. Inspired by/resolves #150.

- Fixes 2 occurences of a cvar typo;
- Cleans up 9 occurences of cvars overridden by vscript;
- Cleans up 14 occurences of inheritable cvars;
- Removes 2 deprecated? cvars;
- Cleans up 2 occurences of an inheritable flag;
- Removes 1 cvar with the default value;
- Removes 4 cvars with default values and 2 inheritable ones, that consequently kinda break completeness/symmetry.

The PR also trims trailing whitespace, cleans up 3 bad newlines, fixes indentation and removes unnecessary comments (and adds 2).