### PR TITLE
Fix L4D2 Talker regarding uncommon infected

### DIFF
--- a/root/scripts/talker/coach.txt
+++ b/root/scripts/talker/coach.txt
@@ -3326,6 +3326,14 @@ Rule EllisStoryInterruptGenericC4M4Coach
 	Response EllisStoryInterruptGenericCoach
 }
 
+Rule EllisStoryInterruptGenericC4M5Coach
+{
+	criteria ConceptEllisInterrupt IsCoach isc4m5 _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericCoach
+}
+
 Rule EllisStoryInterruptGenericC5M2Coach
 {
 	criteria ConceptEllisInterrupt IsCoach IsMapc5m2_park _auto_IsTellingStory _auto_NotDidInterrupt
@@ -3352,6 +3360,29 @@ Rule EllisStoryReac01Coach
 	Response EllisStoryReac01Coach
 }
 
+Rule EllisStoryInterruptC13M2Coach
+{
+	criteria ConceptEllisInterrupt IsCoach IsMapc13m2_southpinestream _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericCoach
+}
+
+Rule EllisStoryInterruptC13M3Coach
+{
+	criteria ConceptEllisInterrupt IsCoach IsMapc13m3_memorialbridge _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericCoach
+}
+
+Rule EllisStoryInterruptC13M4Coach
+{
+	criteria ConceptEllisInterrupt IsCoach IsMapc13m4_cutthroatcreek _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericCoach
+}
 
 //--------------------------------------------------------------------------------------------------------------
 // C5M5
@@ -4941,6 +4972,7 @@ Rule SurvivorSpottedWorldCloseCoach
 Response SurvivorSpottedArmoredCoach
 {
 	norepeat
+	scene "scenes/Coach/SeeArmored01.vcd"  //That zombie's got armor. I want armor!
 	scene "scenes/Coach/SeeArmored03.vcd"  //Shoot that zombie in the back!
 	scene "scenes/Coach/SeeArmored04.vcd"  //Shoot that zombie in the back!
 }
@@ -4954,14 +4986,14 @@ Rule SurvivorSpottedArmoredCoach
 
 Response SurvivorSpottedArmoredC5M1Coach
 {
-	scene "scenes/Coach/SeeArmored01.vcd"  //That zombie's got armor. I want armor!
+	norepeat
 	scene "scenes/Coach/SeeArmored02.vcd"  //Well I'll be damned, that zombie's wearin' armor!
 	scene "scenes/Coach/SeeArmored05.vcd"  //Those zombies are goddamn bullet proof!
 }
 Rule SurvivorSpottedArmoredC5M1Coach
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeArmored IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidArmoredWarn ismap_c5m1_waterfront IsNotSpeakingWeight0 _auto_NotSpottedVehicle
-	ApplyContext "SaidArmoredWarn:1:0"
+	ApplyContext "SaidArmoredWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedArmoredC5M1Coach
 }
@@ -5061,7 +5093,7 @@ Rule SurvivorSpottedCedaCoach
 Rule SurvivorSpottedCedaC1M1Coach
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:0"
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaCoach
 }
@@ -5144,6 +5176,7 @@ Rule SurvivorSpottedChargerAlsoC1M2Coach
 
 Response SurvivorSpottedClownCoach
 {
+	norepeat
 	scene "scenes/Coach/SeeClowns05.vcd"  //Shoot the clown!
 	scene "scenes/Coach/SeeClowns06.vcd"  //That clown's attracting zombies!
 	scene "scenes/Coach/SeeClowns07.vcd"  //Shoot the clown!
@@ -5181,8 +5214,8 @@ Response SurvivorSpottedFirstClownCoach
 }
 Rule SurvivorSpottedFirstClownCoach
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidClownWarn ismap_c2m2 IsNotSpeakingWeight0
-	ApplyContext "SaidClownWarn:1:0,SawClowns:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidClownWarn ismap_c2m2 SawFirstClown IsNotSpeakingWeight0
+	ApplyContext "SaidClownWarn:1:20,SawClowns:++1"
 	applycontexttoworld
 	Response SurvivorSpottedFirstClownCoach
 }
@@ -5285,6 +5318,7 @@ Rule SurvivorSpottedInfectedCoach
 
 Response SurvivorSpottedJimmyCoach
 {
+	norepeat
 	scene "scenes/Coach/WorldC1M3B21.vcd"  //Heyyy! Jimmy Gibbs!
 	scene "scenes/Coach/WorldC1M4B10.vcd"  //Forgive us Jimmy, but we need your car.
 	scene "scenes/Coach/WorldC1M4B37.vcd"  //Sorry about this, Mr. Gibbs.
@@ -5376,6 +5410,7 @@ Rule SurvivorSpottedJockeyAlsoC1M2Coach
 Response SurvivorSpottedMudmenCoach
 {
 	norepeat
+	scene "scenes/Coach/SeeMudmen01.vcd"  //Mudmen!
 	scene "scenes/Coach/SeeMudmen02.vcd"  //Shoot the mudmen!
 }
 Rule SurvivorSpottedMudmenCoach
@@ -5386,16 +5421,12 @@ Rule SurvivorSpottedMudmenCoach
 	Response SurvivorSpottedMudmenCoach
 }
 
-Response SurvivorSpottedMudmenC3M2Coach
-{
-	scene "scenes/Coach/SeeMudmen01.vcd"  //Mudmen!
-}
 Rule SurvivorSpottedMudmenC3M2Coach
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidMudmenWarn IsNotSpeakingWeight0 _auto_NotSpottedVehicle
-	ApplyContext "SaidMudmenWarn:1:0,SawMudMen:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidMudmenWarn IsNotSpeakingWeight0 _auto_NotSpottedVehicle ismapc3m2_swamp
+	ApplyContext "SaidMudmenWarn:1:20,SawMudMen:++1"
 	applycontexttoworld
-	Response SurvivorSpottedMudmenC3M2Coach
+	Response SurvivorSpottedMudmenCoach
 }
 
 Response SurvivorSpottedSmokerCoach

--- a/root/scripts/talker/gambler.txt
+++ b/root/scripts/talker/gambler.txt
@@ -3248,6 +3248,19 @@ Rule EllisStoryInterruptC4M4Gambler
 	Response EllisStoryInterruptC4M4Gambler
 }
 
+Response EllisStoryInterruptC4M5Gambler
+{
+	scene "scenes/Gambler/EllisInterrupt07.vcd"  //Hey Ellis, why don't you tell us about the time you SHUT UP?
+	scene "scenes/Gambler/EllisInterrupt20.vcd"  //You know what I like best about your stories, Ellis? NOTHING!
+}
+Rule EllisStoryInterruptC4M5Gambler
+{
+	criteria ConceptEllisInterrupt IsGambler isc4m5 _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptC4M5Gambler
+}
+
 Response EllisStoryInterruptC5M2Gambler
 {
 	scene "scenes/Gambler/EllisInterrupt09.vcd"  //I don't care. NOBODY CARES!
@@ -3272,6 +3285,27 @@ Rule EllisStoryInterruptC5M5Gambler
 	Response EllisStoryInterruptC5M5Gambler
 }
 
+Rule EllisStoryInterruptC13M2Gambler
+{
+	criteria ConceptEllisInterrupt IsGambler IsMapc13m2_southpinestream _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericGambler
+}
+Rule EllisStoryInterruptC13M3Gambler
+{
+	criteria ConceptEllisInterrupt IsGambler IsMapc13m3_memorialbridge _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericGambler
+}
+Rule EllisStoryInterruptC13M4Gambler
+{
+	criteria ConceptEllisInterrupt IsGambler ismapc13m4_cutthroatcreek _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptC5M5Gambler
+}
 
 //--------------------------------------------------------------------------------------------------------------
 // C5M5
@@ -5041,13 +5075,14 @@ Rule SurvivorSpottedWorldCloseGambler
 //--------------------------------------------------------------------------------------------------------------
 Response SurvivorSpottedArmoredC5M1Gambler
 {
+	norepeat
 	scene "scenes/Gambler/SeeArmored01.vcd"  //Those zombies are wearing armor?
 	scene "scenes/Gambler/SeeArmored02.vcd"  //Those zombies are wearing armor!
 }
 Rule SurvivorSpottedArmoredC5M1Gambler
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeArmored IsNotCoughing IsGambler IsTalk IsTalkGambler IsWorldTalkGambler IsNotIncapacitated ismap_c5m1_waterfront IsNotSaidArmoredWarn IsNotSpeakingWeight0 _auto_NotSpottedVehicle
-	ApplyContext "SaidArmoredWarn:1:0"
+	ApplyContext "SaidArmoredWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedArmoredC5M1Gambler
 }
@@ -5163,8 +5198,8 @@ Rule SurvivorSpottedBoomerAlsoC1M2Gambler
 Response SurvivorSpottedCedaGambler
 {
 	norepeat
-	scene "scenes/Gambler/SeeHazmat01.vcd"  //Hazmat guys!
-	scene "scenes/Gambler/SeeHazmat03.vcd"  //Are those guys fireproof?
+	scene "scenes/Gambler/SeeHazmat01.vcd" //Hazmat guys!
+	scene "scenes/Gambler/SeeHazmat03.vcd" //Are those guys fireproof?
 }
 Rule SurvivorSpottedCedaGambler
 {
@@ -5177,12 +5212,12 @@ Rule SurvivorSpottedCedaGambler
 Response SurvivorSpottedCedaC1M1Gambler
 {
 	norepeat
-	scene "scenes/Gambler/SeeHazmat02.vcd"  //Guess those suits don't stop bites.
+	scene "scenes/Gambler/SeeHazmat02.vcd" //Guess those suits don't stop bites.
 }
 Rule SurvivorSpottedCedaC1M1Gambler
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsGambler IsTalk IsTalkGambler IsWorldTalkGambler IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:0"
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaC1M1Gambler
 }
@@ -5265,20 +5300,18 @@ Rule SurvivorSpottedChargerAlsoC1M2Gambler
 	Response SurvivorSpottedChargerC1M1Gambler
 }
 
-Response SurvivorSpottedClownC2M2Gambler
-{
-	scene "scenes/Gambler/SeeClowns01.vcd"  //That squeaking is driving the zombies crazy!
-}
 Rule SurvivorSpottedClownC2M2Gambler
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsGambler IsTalk IsTalkGambler IsWorldTalkGambler IsNotIncapacitated Ismap_c2m2 IsNotSaidClownWarn IsNotSpeakingWeight0
-	ApplyContext "SaidClownWarn:1:0,SawClowns:++1"
+	ApplyContext "SaidClownWarn:1:20,SawClowns:++1"
 	applycontexttoworld
-	Response SurvivorSpottedClownC2M2Gambler
+	Response SurvivorSpottedClownGambler
 }
 
 Response SurvivorSpottedClownGambler
 {
+	norepeat
+	scene "scenes/Gambler/SeeClowns01.vcd"  //That squeaking is driving the zombies crazy!
 	scene "scenes/Gambler/SeeClowns02.vcd"  //Kill the clown!
 	scene "scenes/Gambler/SeeClowns03.vcd"  //Kill the clown, he's attracting more zombies!
 	scene "scenes/Gambler/SeeClowns04.vcd"  //Kill every clown you see!
@@ -5516,13 +5549,14 @@ Rule SurvivorSpottedMudmenGambler
 Rule SurvivorSpottedMudmenC3M2Gambler
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsGambler IsTalk IsTalkGambler IsWorldTalkGambler IsNotIncapacitated IsNotSaidMudmenWarn ismapc3m2_swamp IsNotSpeakingWeight0
-	ApplyContext "SaidMudmenWarn:1:0,SawMudMen:++1"
+	ApplyContext "SaidMudmenWarn:1:20,SawMudMen:++1"
 	applycontexttoworld
 	Response SurvivorSpottedMudmenGambler
 }
 
 Response SurvivorSpottedMudmen2Gambler
 {
+	norepeat
 	scene "scenes/Gambler/WorldC3M201.vcd"  //Screw these goddamn mud people.
 }
 Rule SurvivorSpottedMudmen2Gambler

--- a/root/scripts/talker/mechanic.txt
+++ b/root/scripts/talker/mechanic.txt
@@ -4922,6 +4922,19 @@ Rule C4M4EllisStoryMechanic
 	Response C4M4EllisStoryMechanic
 }
 
+Response C4M5EllisStoryMechanic
+{
+	scene "scenes/Mechanic/DLC1_COMMUNITYE23.vcd"  then any EllisInterrupt foo:0 -4.20	//"I ever tell you about the time my buddy Keith told me that he was picked up by some little green men and they..."
+}
+Rule C4M5EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking isc4m5 IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C4M5EllisStoryMechanic
+}
+
 Response C5M2EllisStoryMechanic
 {
 	scene "scenes/Mechanic/EllisStoriesF01.vcd"  then any EllisInterrupt foo:0 -8.54 //Do you know what suck the heads means?  Because I came down here with Keith once and he didn't know and... It ain't nothin' bad.  It's about eatin'.
@@ -5056,6 +5069,44 @@ Rule EllisStoryReac01GoatMechanic
 	Response EllisStoryReac01GoatMechanic
 }
 
+Response C13M2EllisStoryMechanic
+{
+	scene "scenes/Mechanic/EllisStoriesL01.vcd"  then any EllisInterrupt foo:0 -15.53 //I ever tell you guys about the time my buddy Keith got rolled by a gator in a swamp? He didn't antagonize it or nothing, we were just trying to grab two so we could piss them off and get 'em to fight.
+}
+Rule C13M2EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking IsMapc13m2_southpinestream IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C13M2EllisStoryMechanic
+}
+
+Response C13M3EllisStoryMechanic
+{
+	scene "scenes/Mechanic/DLC1_KeithStories01.vcd"  then any EllisInterrupt foo:0 -16.0 //This one time, my buddy, Keith, got a tattoo. "I'M A MORON!" Right across his forehead. Of course, he made $200 off of that. So you ask yourself. Who's the REAL moron, huh?
+}
+Rule C13M3EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking IsMapc13m3_memorialbridge IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C13M3EllisStoryMechanic
+}
+
+Response C13M4EllisStoryMechanic
+{
+	scene "scenes/Mechanic/EllisStoriesS01.vcd"  then any EllisInterrupt foo:0 -18.21 //One the time the army bombed my buddy Keith. He went camping and didn't bother reading the signs, and I guess they were testing bombs that day-all sorts of stuff too, not just regular bombs.
+}
+Rule C13M4EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking IsMapc13m4_cutthroatcreek IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C13M4EllisStoryMechanic
+}
 
 //--------------------------------------------------------------------------------------------------------------
 // Finale Speech
@@ -5701,13 +5752,14 @@ Rule SurvivorSpottedArmoredMechanic
 
 Response SurvivorSpottedArmoredC5M1Mechanic
 {
+	norepeat
 	scene "scenes/Mechanic/SeeArmored01.vcd"  //Aw, hell, now they're bulletproof?
 	scene "scenes/Mechanic/SeeArmored02.vcd"  //Aw, hell, they're bulletproof!
 }
 Rule SurvivorSpottedArmoredC5M1Mechanic
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeArmored IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidArmoredWarn ismap_c5m1_waterfront IsNotSpeakingWeight0
-	ApplyContext "SaidArmoredWarn:1:0"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeArmored IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidArmoredWarn ismap_c5m1_waterfront IsNotSpeakingWeight0 _auto_NotSpottedVehicle
+	ApplyContext "SaidArmoredWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedArmoredC5M1Mechanic
 }
@@ -5809,12 +5861,13 @@ Rule SurvivorSpottedCedaMechanic
 
 Response SurvivorSpottedCedaC1M1Mechanic
 {
+	norepeat
 	scene "scenes/Mechanic/SeeHazmat02.vcd"  //Watch out for the ones in the hazmat suits.
 }
 Rule SurvivorSpottedCedaC1M1Mechanic
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:0"
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaC1M1Mechanic
 }
@@ -5878,12 +5931,14 @@ Rule SurvivorSpottedCharger2C1Mechanic
 
 Response SurvivorSpottedClownMechanic
 {
+	norepeat
 	scene "scenes/Mechanic/SeeClowns01.vcd"  //That clown's bringing friends! Take him down!
 	scene "scenes/Mechanic/SeeClowns02.vcd"  //We gotta shut that clown up!
 	scene "scenes/Mechanic/SeeClowns03.vcd"  //Hey, take that clown down!
 	scene "scenes/Mechanic/SeeClowns04.vcd"  //Take that clown down!
 	scene "scenes/Mechanic/SeeClowns05.vcd"  //Take the clown down!
 	scene "scenes/Mechanic/SeeClowns06.vcd"  //Take down that clown!
+	scene "scenes/Mechanic/SeeClowns07.vcd"  //Man, I've never been so scared of clowns.
 }
 Rule SurvivorSpottedClownMechanic
 {
@@ -5913,14 +5968,13 @@ Rule SurvivorSpottedFallenMechanic
 
 Response SurvivorSpottedFirstClownMechanic
 {
-	scene "scenes/Mechanic/SeeClowns07.vcd"  //Man, I've never been so scared of clowns.
 	scene "scenes/Mechanic/SeeClowns08.vcd"  //Clowns!
 	scene "scenes/Mechanic/SeeClowns09.vcd"  //Clowns? Clowns. Oh, you have got to be kidding me.
 }
 Rule SurvivorSpottedFirstClownMechanic
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidClownWarn ismap_c2m2 IsNotSpeakingWeight0
-	ApplyContext "SaidClownWarn:1:0,SawClowns:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidClownWarn ismap_c2m2 SawFirstClown IsNotSpeakingWeight0
+	ApplyContext "SaidClownWarn:1:20,SawClowns:++1"
 	applycontexttoworld
 	Response SurvivorSpottedFirstClownMechanic
 }
@@ -5997,6 +6051,7 @@ Rule SurvivorSpottedInfectedMechanic
 
 Response SurvivorSpottedJimmyMechanic
 {
+	norepeat
 	scene "scenes/Mechanic/GrabbedBySmoker02b.vcd"  //NOOOOOOO!!!!
 }
 Rule SurvivorSpottedJimmyMechanic
@@ -6070,8 +6125,8 @@ Response SurvivorSpottedMudmenC3M2Mechanic
 }
 Rule SurvivorSpottedMudmenC3M2Mechanic
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidMudmenWarn ismapc3m2_swamp IsNotSpeakingWeight0
-	ApplyContext "SaidMudmenWarn:1:0,SawMudMen:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidMudmenWarn ismapc3m2_swamp SawFirstMudMen IsNotSpeakingWeight0
+	ApplyContext "SaidMudmenWarn:1:20,SawMudMen:++1"
 	applycontexttoworld
 	Response SurvivorSpottedMudmenC3M2Mechanic
 }
@@ -6095,6 +6150,7 @@ Rule SurvivorSpottedMudmenMechanic
 
 Response SurvivorSpottedMudmen2Mechanic
 {
+	norepeat
 	scene "scenes/Mechanic/WorldC3M236.vcd"  then gambler Player.SeeMudmen2a foo:0 -2.938 //I got a new thing I hate: mud people.
 	scene "scenes/Mechanic/WorldC3M237.vcd"  //Tell you what, mud people take all the fun out of the mud.
 }

--- a/root/scripts/talker/producer.txt
+++ b/root/scripts/talker/producer.txt
@@ -2643,6 +2643,14 @@ Rule EllisStoryInterruptC4M4Producer
 	Response EllisStoryInterruptGenericProducer
 }
 
+Rule EllisStoryInterruptC4M5Producer
+{
+	criteria ConceptEllisInterrupt IsProducer isc4m5 _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericProducer
+}
+
 Rule EllisStoryInterruptC5M2Producer
 {
 	criteria ConceptEllisInterrupt IsProducer IsMapc5m2_park _auto_IsTellingStory _auto_NotDidInterrupt
@@ -2680,6 +2688,30 @@ Rule EllisStoryReac01Producer
 {
 	criteria ConceptEllisStoryReac01 IsProducer ismapc3m2_swamp
 	Response EllisStoryReac01Producer
+}
+
+Rule EllisStoryInterruptC13M2Producer
+{
+	criteria ConceptEllisInterrupt IsProducer IsMapc13m2_southpinestream _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericProducer
+}
+
+Rule EllisStoryInterruptC13M3Producer
+{
+	criteria ConceptEllisInterrupt IsProducer IsMapc13m3_memorialbridge _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericProducer
+}
+
+Rule EllisStoryInterruptC13M4Producer
+{
+	criteria ConceptEllisInterrupt IsProducer IsMapc13m4_cutthroatcreek _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericProducer
 }
 
 //--------------------------------------------------------------------------------------------------------------
@@ -4729,12 +4761,13 @@ Rule SurvivorSpottedWorldCloseProducer
 //--------------------------------------------------------------------------------------------------------------
 Response SurvivorSpottedArmoredC5M1Producer
 {
+	norepeat
 	scene "scenes/Producer/SeeArmored01.vcd"  //Are these things bulletproof?
 }
 Rule SurvivorSpottedArmoredC5M1Producer
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeArmored IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated ismap_c5m1_waterfront IsNotSaidArmoredWarn IsNotSpeakingWeight0
-	ApplyContext "SaidArmoredWarn:1:0"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeArmored IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated ismap_c5m1_waterfront IsNotSaidArmoredWarn IsNotSpeakingWeight0 _auto_NotSpottedVehicle
+	ApplyContext "SaidArmoredWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedArmoredC5M1Producer
 }
@@ -4835,7 +4868,7 @@ Rule SurvivorSpottedBoomerAlsoC1M2Producer
 Response SurvivorSpottedCedaProducer
 {
 	norepeat
-	scene "scenes/Producer/SeeHazmat02.vcd"  //Fireproof zombies. Hooray!
+	scene "scenes/Producer/SeeHazmat02.vcd" //Fireproof zombies. Hooray!
 	scene "scenes/Producer/SeeHazmat03.vcd" //Shit. I think these guys are fireproof.
 }
 Rule SurvivorSpottedCedaProducer
@@ -4848,12 +4881,13 @@ Rule SurvivorSpottedCedaProducer
 
 Response SurvivorSpottedCedaC1M1Producer
 {
+	norepeat
 	scene "scenes/Producer/SeeHazmat01.vcd"  //Great. Infected in hazmat suits.
 }
 Rule SurvivorSpottedCedaC1M1Producer
 {
 	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:0"
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaC1M1Producer
 }
@@ -4937,10 +4971,13 @@ Rule SurvivorSpottedChargerAlsoC1M2Producer
 
 Response SurvivorSpottedClownProducer
 {
+	norepeat
+	scene "scenes/Producer/SeeClowns01.vcd"  //That clown's attracting a horde!
 	scene "scenes/Producer/SeeClowns03.vcd"  //Somebody shut that clown up!
 	scene "scenes/Producer/SeeClowns04.vcd"  //Somebody shut up that clown!
 	scene "scenes/Producer/SeeClowns05.vcd"  //Kill the clown!
 	scene "scenes/Producer/SeeClowns06.vcd"  //Kill the clown!
+	scene "scenes/Producer/SeeClowns07.vcd"  //The clown's attracting a horde!
 }
 Rule SurvivorSpottedClownProducer
 {
@@ -4952,14 +4989,12 @@ Rule SurvivorSpottedClownProducer
 
 Response SurvivorSpottedClownC2M2Producer
 {
-	scene "scenes/Producer/SeeClowns01.vcd"  //That clown's attracting a horde!
 	scene "scenes/Producer/SeeClowns02.vcd"  //Okay, that clown's attracting a horde!
-	scene "scenes/Producer/SeeClowns07.vcd"  //The clown's attracting a horde!
 }
 Rule SurvivorSpottedClownC2M2Producer
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidClownWarn ismap_c2m2 IsNotSpeakingWeight0
-	ApplyContext "SaidClownWarn:1:0,SawClowns:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeClown IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidClownWarn ismap_c2m2 SawFirstClown IsNotSpeakingWeight0
+	ApplyContext "SaidClownWarn:1:20,SawClowns:++1"
 	applycontexttoworld
 	Response SurvivorSpottedClownC2M2Producer
 }
@@ -5078,8 +5113,10 @@ Rule SurvivorSpottedInfectedProducer
 
 Response SurvivorSpottedJimmyProducer
 {
+	norepeat
 	scene "scenes/Producer/WorldC1M3B17.vcd"  //Take that, Jimmy Gibbs!
 	scene "scenes/Producer/WorldC1M3B18.vcd"  //Eat lead, Jimmy Gibbs.
+	scene "scenes/Producer/WorldC1M4B12.vcd"  //Dibs on Gibbs!
 }
 Rule SurvivorSpottedJimmyProducer
 {
@@ -5191,8 +5228,8 @@ Response SurvivorSpottedMudmenFirstProducer
 }
 Rule SurvivorSpottedMudmenFirstProducer
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidMudmenWarn ismapc3m2_swamp IsNotSpeakingWeight0
-	ApplyContext "SaidMudmenWarn:1:0,SawMudMen:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeMudmen IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidMudmenWarn ismapc3m2_swamp SawFirstMudMen IsNotSpeakingWeight0
+	ApplyContext "SaidMudmenWarn:1:20,SawMudMen:++1"
 	applycontexttoworld
 	Response SurvivorSpottedMudmenFirstProducer
 }


### PR DESCRIPTION
Fixes l4d2 survivors from being unable to call out uncommon infected on certain maps
Adds "norepeat" to the uncommon infected callouts that were missing it, to be consistent
Adds an Ellis story to c4m5, c13m2, c13m3, an c13m4