### PR TITLE
Population_Versus Update

### DIFF
--- a/root/scripts/population_versus.txt
+++ b/root/scripts/population_versus.txt
@@ -1,0 +1,70 @@
+Population
+{
+	//------------------------------------------------------------------------
+	// Areas are defined in the map or the nav file.  Right now we're using
+	// nav place names.  If no place name is used, we look for 'default'.
+	// Populations are lists of models, with percentages adding up to 100.
+	// Model names should be specified without the .mdl extension, and
+	// without the directory name (this assumes all infected models are in
+	// models/infected).
+
+	
+
+	//------------------------------------------------------------------------
+	deepswamp_parachutist
+	{
+		common_male_tshirt_cargos_swamp		25
+		common_male_tankTop_overalls_swamp	40
+		common_female_tshirt_skirt_swamp	25
+		common_male_mud				10
+	}
+
+	riverbank
+	{
+		common_female_tshirt_skirt		45
+		common_male_dressShirt_jeans	55
+		
+		survivor_biker_light	0
+		survivor_teenangst_light	0
+	}
+
+	defaultlots_l4d1
+	{
+		common_male01		15
+		common_male02		15
+		common_female01		15
+		common_police_male01	15
+		common_military_male01	10
+		common_worker_male01	10
+		common_male_suit 	10
+		common_female01_suit 	10
+	}
+
+	maintenancestreet_l4d1
+	{
+		common_male01		15
+		common_male02		15
+		common_female01		20
+		common_military_male01	20
+		common_worker_male01	30
+	}
+
+	ruralstreet_l4d1
+	{
+		common_male_rural01 	45
+		common_female_rural01	25
+		common_police_male01	10
+		common_military_male01	10
+		common_worker_male01	10
+	}
+
+	lighthouse_l4d1
+	{
+		common_male01		16
+		common_male02		16
+		common_female01		16
+		common_worker_male01	16
+		common_male_rural01 	18
+		common_female_rural01	18
+	}
+}


### PR DESCRIPTION
Removes the fallen survivor (parachutist) from Swamp Fever's 2nd map to be consistent with the other maps which added fallen survivors in TLS but removed them from the versus maps for balance. c3m2_swamp already has an extremely generous supply of resources for survivors, and doesn't need fallen survivors giving additional supplies to whichever versus team gets better rng.