### PR TITLE
Hard Rain Finale Update

### DIFF
--- a/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
+++ b/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
@@ -55,6 +55,7 @@ DirectorOptions <-
 	 
 	 A_CustomFinale5 = PANIC
 	 A_CustomFinaleValue5 = 1
+	 A_CustomFinaleMusic5 	= "Event.FinaleWave4"
 	 
 	 A_CustomFinale6 = DELAY
 	 A_CustomFinaleValue6 = 10
@@ -70,9 +71,17 @@ DirectorOptions <-
 	CommonLimit = 20
 	SpecialRespawnInterval = 80
 
+	MusicDynamicMobSpawnSize = 8
+	MusicDynamicMobStopSize = 2
+	MusicDynamicMobScanStopSize = 1
 
 }
 
+if ( Director.GetGameModeBase() == "versus" )
+{
+	DirectorOptions.A_CustomFinaleValue1 = 2
+	DirectorOptions.A_CustomFinaleValue5 = 2
+}
 
 if ( "DirectorOptions" in LocalScript && "ProhibitBosses" in LocalScript.DirectorOptions )
 {


### PR DESCRIPTION
1. Adds "final nail" music to the finale, to match the l4d1 holout finales -- it will play after the first tank is defeated and the 2nd horde is approaching
2. Adds some lines for "MusicDynamic" to fix the combat music not playing during this finale, making things strangely quiet and unclimactic
3. In versus mode, there will now be two hordes that spawn in each wave instead of only one, to make this finale consistent with other l4d2 & l4d1 finales. Only one horde spawning each wave is fine for campaign, but in versus mode it gives the infected team very little time to plan an attack or spawn because their time limit is literally halved. This change will balance versus mode without affecting campaign.