### PR TITLE
Population_Versus.txt Update

### DIFF
--- a/root/scripts/population_versus.txt
+++ b/root/scripts/population_versus.txt
@@ -11,6 +11,14 @@ Population
 	
 
 	//------------------------------------------------------------------------
+	deepswamp_parachutist
+	{
+		common_female_tshirt_skirt_swamp	25
+		common_male_tankTop_overalls_swamp	40
+		common_male_tshirt_cargos_swamp		25
+		common_male_mud				10
+	}
+
 	riverbank
 	{
 		common_female_tshirt_skirt		45

--- a/root/scripts/population_versus.txt
+++ b/root/scripts/population_versus.txt
@@ -1,0 +1,62 @@
+Population
+{
+	//------------------------------------------------------------------------
+	// Areas are defined in the map or the nav file.  Right now we're using
+	// nav place names.  If no place name is used, we look for 'default'.
+	// Populations are lists of models, with percentages adding up to 100.
+	// Model names should be specified without the .mdl extension, and
+	// without the directory name (this assumes all infected models are in
+	// models/infected).
+
+	
+
+	//------------------------------------------------------------------------
+	riverbank
+	{
+		common_female_tshirt_skirt		45
+		common_male_dressShirt_jeans	55
+		
+		survivor_biker_light	0
+		survivor_teenangst_light	0
+	}
+
+	defaultlots_l4d1
+	{
+		common_male01		15
+		common_male02		15
+		common_female01		15
+		common_police_male01	15
+		common_military_male01	10
+		common_worker_male01	10
+		common_male_suit 	10
+		common_female01_suit 	10
+	}
+
+	maintenancestreet_l4d1
+	{
+		common_male01		15
+		common_male02		15
+		common_female01		20
+		common_military_male01	20
+		common_worker_male01	30
+	}
+
+	ruralstreet_l4d1
+	{
+		common_male_rural01 	45
+		common_female_rural01	25
+		common_police_male01	10
+		common_military_male01	10
+		common_worker_male01	10
+	}
+
+	lighthouse_l4d1
+	{
+		common_male01		16
+		common_male02		16
+		common_female01		16
+		common_worker_male01	16
+		common_male_rural01 	18
+		common_female_rural01	18
+	}
+}


### PR DESCRIPTION
# What exactly is changed and why?

Removes the fallen survivors (parachutists) from the versus version of Swamp Fever to be consistent with the other versus maps. In TLS, fallen survivors were added to different campaign levels, but each was removed from the versus version of the map for game balance. Since c3m2 already has generous supplies for survivors, there is no need for parachutists to spawn in the versus map.

In Summary: All the other maps that had fallen survivors added to them in TLS had the "fallen" removed from versus mode so they wouldn't affect game balance, however, the parachutists were kept in versus, presumably due to oversight. This removes them for versus mode, to be consistent with the other maps, and also for game balance, as they spawned extra supplies for survivors than normal.

# Is there anything specific that needs review?

No.

# Does this address any open issues?
Fixes #306 