### PR TITLE
Fix for abundance of medkits in l4d1 mutations

### DIFF
--- a/root/scripts/vscripts/l4d1.nut
+++ b/root/scripts/vscripts/l4d1.nut
@@ -26,7 +26,7 @@ DirectorOptions <-
 	weaponsToConvert =
 	{
 		weapon_shotgun_spas				= "weapon_autoshotgun_spawn"
-		weapon_defibrillator			= "weapon_first_aid_kit_spawn"
+		weapon_defibrillator			= "weapon_pain_pills_spawn"
 		weapon_ammo_pack				= "weapon_first_aid_kit_spawn"
 		weapon_sniper_awp				= "weapon_hunting_rifle_spawn"
 		weapon_sniper_military			= "weapon_hunting_rifle_spawn"


### PR DESCRIPTION
Defibs were being converted into medkits, but this was causing the game to keep trying to spawn more defibs, which were each being converted into medkits. Now, defibs will spawn as pain pills, which seems to have fixed the oversaturation of healing items.