### PR TITLE
Improve visibility and flexibility in nav_compare.nut

### DIFF
--- a/tools/nav_compare.nut
+++ b/tools/nav_compare.nut
@@ -1,86 +1,112 @@
 //Nescius' navmesh comparison script
-//0. script_execute nav_compare
-//1. load old nav
-//2. script Store()
-//3. load new nav (nav_load)
-//4. script Compare()
+//1. load map with old nav
+//2. script_execute nav_compare
+//3. script Store()
+//4. load new nav (nav_load)
+//5. script Compare()
 
 //g_ModeScript.DeepPrintTable(allAreas);
 //DebugDrawBoxAngles(Vector origin, Vector min, Vector max, QAngle direction, Vector rgb, int alpha, float duration)
 
-function DebugDrawNavBox(a, b, color, alpha, pad=2, duration=99999) {
-	local center = (a + b) * 0.5;
-	DebugDrawBoxAngles(center, center - a - Vector(pad,pad,0), center - b + Vector(pad,pad,0), QAngle(0,0,0), color, alpha, duration);
+function DebugDrawNavBox(area, color, alpha, duration=99999) {
+    local center, a, b, xSize, ySize, pad;
+
+    if(typeof area == "table") {
+        center = area.origin;
+        a = area.nw;
+        b = area.se;
+        xSize = area.xSize;
+        ySize = area.ySize;
+    }
+    else {
+        center = area.GetCenter();
+        a = area.GetCorner(0);
+        b = area.GetCorner(2);
+        xSize = area.GetSizeX();
+        ySize = area.GetSizeY();
+    }
+
+    if(xSize < 8 || ySize < 8)
+        pad = 1;
+    else if(xSize < 15 || ySize < 15)
+        pad = 2;
+    else
+        pad = 5;
+
+    DebugDrawBoxAngles(center, center - a - Vector(pad,pad,0), center - b + Vector(pad,pad,0), QAngle(0,0,0), color, alpha, duration);
 }
 
 function Store() {
-	::storedAreas <- {};
-	local allAreas = {};
-	NavMesh.GetAllAreas(allAreas);
+    ::storedAreas <- {};
+    local allAreas = {};
+    NavMesh.GetAllAreas(allAreas);
 
-	foreach(area in allAreas) {
-		storedAreas[area.GetID()] <- {
-			origin = area.GetCenter(),
-			nw = area.GetCorner(0),
-			ne = area.GetCorner(1),
-			se = area.GetCorner(2),
-			sw = area.GetCorner(3),
-			xSize = area.GetSizeX(),
-			ySize = area.GetSizeY(),
-			spawnAttr = area.GetSpawnAttributes(),
-			attr = area.GetAttributes(),
-		}
-	}
+    foreach(area in allAreas) {
+        storedAreas[area.GetID()] <- {
+            origin = area.GetCenter(),
+            nw = area.GetCorner(0),
+            ne = area.GetCorner(1),
+            se = area.GetCorner(2),
+            sw = area.GetCorner(3),
+            xSize = area.GetSizeX(),
+            ySize = area.GetSizeY(),
+            spawnAttr = area.GetSpawnAttributes(),
+            attr = area.GetAttributes(),
+        };
+    }
 }
 
 ::comp <- function(k) {
-	local area = storedAreas[k];
-	local r = 0, g = 0, b = 0;
-	local rayStart = area.origin + Vector(0,0,50);
-	local rayEnd = rayStart - Vector(0,0,100);
-	local newArea = NavMesh.FindNavAreaAlongRay(rayStart, rayEnd, null);
+    local area = storedAreas[k];
+    local r = 0, g = 0, b = 0;
+    local rayStart = area.origin + Vector(0,0,50);
+    local rayEnd = rayStart - Vector(0,0,100);
+    local newArea = NavMesh.FindNavAreaAlongRay(rayStart, rayEnd, null);
 
-	if(newArea) {
-		if(newArea.GetSizeX() != area.xSize || newArea.GetSizeY() != area.ySize) {
-			r = 255;
-		}
-		if((newArea.GetSpawnAttributes() ^ area.spawnAttr) & ~117587968) {
-			g = 255;
-		}
-		if((newArea.GetAttributes() ^ area.attr) & ~(-134217728)) {
-			b = 255;
-		}
+    if(newArea) {
+        if(newArea.GetSizeX() != area.xSize || newArea.GetSizeY() != area.ySize) {
+            r = 255;
+        }
+        if((newArea.GetSpawnAttributes() ^ area.spawnAttr) & ~117587968) {
+            g = 255;
+        }
+        if((newArea.GetAttributes() ^ area.attr) & ~(-134217728)) {
+            b = 255;
+        }
 
-		if(r||g||b) {
-			DebugDrawNavBox(area.nw, area.se, Vector(r,g,b), 128);
-			//newArea.DebugDrawFilled(r, g, b, 150, 999999, true);
-		}
-		newAreas.rawdelete(newArea.GetID());
-	}
-	else {
-		DebugDrawNavBox(area.nw, area.se, Vector(64,0,0), 192, 1);
-	}
+        if(r||g||b) {
+            DebugDrawNavBox(area, Vector(r,g,b), 128);
+            //newArea.DebugDrawFilled(r, g, b, 150, 999999, true);
+        }
+        newAreas.rawdelete(newArea.GetID());
+    }
+    else {
+        DebugDrawNavBox(area, Vector(64,0,0), 192);
+    }
 }
 
 ::drawNew <- function() {
-	foreach(area in newAreas) {
-		DebugDrawNavBox(area.GetCorner(0), area.GetCorner(2), Vector(255,255,255), 192, 1);
-	}
+    foreach(area in newAreas) {
+        if(area.GetSizeX() < 15 || area.GetSizeY() < 15)
+            DebugDrawNavBox(area, Vector(255,255,255), 192);
+        else
+            area.DebugDrawFilled(255, 255, 255, 192, 99999, true);
+    }
 }
 
 function Compare(delay=0.00025) {
-	DebugDrawClear();
-	local i = 0;
+    DebugDrawClear();
+    local i = 0;
 
-	::newAreas <- {};
-	local allAreas = {};
-	NavMesh.GetAllAreas(allAreas);
-	foreach(area in allAreas) {
-		newAreas[area.GetID()] <- area;
-	}
+    ::newAreas <- {};
+    local allAreas = {};
+    NavMesh.GetAllAreas(allAreas);
+    foreach(area in allAreas) {
+        newAreas[area.GetID()] <- area;
+    }
 
-	foreach(k, area in storedAreas) {
-		EntFire("worldspawn", "RunScriptCode", format("comp(%d)", k), delay*i++);
-	}
-	EntFire("worldspawn", "RunScriptCode", "drawNew()", delay*i);
+    foreach(k, area in storedAreas) {
+        EntFire("worldspawn", "RunScriptCode", format("comp(%d)", k), delay*i++);
+    }
+    EntFire("worldspawn", "RunScriptCode", "drawNew()", delay*i);
 }

--- a/tools/nav_compare.nut
+++ b/tools/nav_compare.nut
@@ -1,85 +1,86 @@
-//Nescius's navmesh comparison script
-//1.load old nav
-//2.script Store()
-//3.load new nav
-//4.script Compare()
+//Nescius' navmesh comparison script
+//0. script_execute nav_compare
+//1. load old nav
+//2. script Store()
+//3. load new nav (nav_load)
+//4. script Compare()
 
 //g_ModeScript.DeepPrintTable(allAreas);
 //DebugDrawBoxAngles(Vector origin, Vector min, Vector max, QAngle direction, Vector rgb, int alpha, float duration)
 
-function DebugDrawRectangle(a, b, color, alpha, duration) {
-    local center = (a + b) * 0.5;
-    DebugDrawBoxAngles(center, center - a - Vector(5,5,0), center - b + Vector(5,5,0) , QAngle(0,0,0), color, alpha, duration)
+function DebugDrawNavBox(a, b, color, alpha, pad=2, duration=99999) {
+	local center = (a + b) * 0.5;
+	DebugDrawBoxAngles(center, center - a - Vector(pad,pad,0), center - b + Vector(pad,pad,0), QAngle(0,0,0), color, alpha, duration);
 }
 
 function Store() {
-    ::storedAreas <- {};
-    local allAreas = {};
-    NavMesh.GetAllAreas(allAreas);
+	::storedAreas <- {};
+	local allAreas = {};
+	NavMesh.GetAllAreas(allAreas);
 
-    foreach(area in allAreas) {
-        storedAreas[area.GetID()] <- {
-            origin = area.GetCenter(),
-            nw = area.GetCorner(0),
-            ne = area.GetCorner(1),
-            se = area.GetCorner(2),
-            sw = area.GetCorner(3),
-            xSize = area.GetSizeX(),
-            ySize = area.GetSizeY(),
-            spawnAttr = area.GetSpawnAttributes(),
-            attr = area.GetAttributes(),
-        }
-    }
+	foreach(area in allAreas) {
+		storedAreas[area.GetID()] <- {
+			origin = area.GetCenter(),
+			nw = area.GetCorner(0),
+			ne = area.GetCorner(1),
+			se = area.GetCorner(2),
+			sw = area.GetCorner(3),
+			xSize = area.GetSizeX(),
+			ySize = area.GetSizeY(),
+			spawnAttr = area.GetSpawnAttributes(),
+			attr = area.GetAttributes(),
+		}
+	}
 }
 
 ::comp <- function(k) {
-    local area = storedAreas[k];
-    local r = 0, g = 0, b = 0;
-    local rayStart = area.origin + Vector(0,0,50);
-    local rayEnd = rayStart - Vector(0,0,100);
-    local newArea = NavMesh.FindNavAreaAlongRay(rayStart, rayEnd, null);
+	local area = storedAreas[k];
+	local r = 0, g = 0, b = 0;
+	local rayStart = area.origin + Vector(0,0,50);
+	local rayEnd = rayStart - Vector(0,0,100);
+	local newArea = NavMesh.FindNavAreaAlongRay(rayStart, rayEnd, null);
 
-    if(newArea) {
-        if(newArea.GetSizeX() != area.xSize || newArea.GetSizeY() != area.ySize) {
-            r = 255;
-        }
-        if((newArea.GetSpawnAttributes() ^ area.spawnAttr) & ~117587968) {
-            g = 255;
-        }
-        if((newArea.GetAttributes() ^ area.attr) & ~(-134217728)) {
-            b = 255;
-        }
+	if(newArea) {
+		if(newArea.GetSizeX() != area.xSize || newArea.GetSizeY() != area.ySize) {
+			r = 255;
+		}
+		if((newArea.GetSpawnAttributes() ^ area.spawnAttr) & ~117587968) {
+			g = 255;
+		}
+		if((newArea.GetAttributes() ^ area.attr) & ~(-134217728)) {
+			b = 255;
+		}
 
-        if(r||g||b) {
-            DebugDrawRectangle(area.nw, area.se, Vector(r,g,b), 128, 9999);
-            //newArea.DebugDrawFilled(r, g, b, 150, 999999, true);
-        }
-        newAreas.rawdelete(newArea.GetID());
-    }
-    else {
-        DebugDrawRectangle(area.nw, area.se, Vector(0,0,0), 128, 9999);
-    }
+		if(r||g||b) {
+			DebugDrawNavBox(area.nw, area.se, Vector(r,g,b), 128);
+			//newArea.DebugDrawFilled(r, g, b, 150, 999999, true);
+		}
+		newAreas.rawdelete(newArea.GetID());
+	}
+	else {
+		DebugDrawNavBox(area.nw, area.se, Vector(64,0,0), 192, 1);
+	}
 }
 
 ::drawNew <- function() {
-    foreach(area in newAreas) {
-        area.DebugDrawFilled(255, 255, 255, 255, 9999, true);
-    }
+	foreach(area in newAreas) {
+		DebugDrawNavBox(area.GetCorner(0), area.GetCorner(2), Vector(255,255,255), 192, 1);
+	}
 }
 
 function Compare(delay=0.00025) {
-    DebugDrawClear();
-    local i = 0;
+	DebugDrawClear();
+	local i = 0;
 
-    ::newAreas <- {};
-    local allAreas = {};
-    NavMesh.GetAllAreas(allAreas);
-    foreach(area in allAreas) {
-        newAreas[area.GetID()] <- area;
-    }
+	::newAreas <- {};
+	local allAreas = {};
+	NavMesh.GetAllAreas(allAreas);
+	foreach(area in allAreas) {
+		newAreas[area.GetID()] <- area;
+	}
 
-    foreach(k, area in storedAreas) {
-        EntFire("worldspawn", "RunScriptCode", format("comp(%d)", k), delay*i++);
-    }
-    EntFire("worldspawn", "RunScriptCode", "drawNew()", delay*i);
+	foreach(k, area in storedAreas) {
+		EntFire("worldspawn", "RunScriptCode", format("comp(%d)", k), delay*i++);
+	}
+	EntFire("worldspawn", "RunScriptCode", "drawNew()", delay*i);
 }


### PR DESCRIPTION
This PR:
- Makes the intro tutorial more clear/explicit;
- Replaces `DebugDrawRectangle` with the more flexible `DebugDrawNavBox` which supports different padding internally (decreasing the default padding is very important to allow small nav areas to display!);
- Switches the black/gray color for deleted nav areas to dark red to greatly improve visibility in dark areas (this color may not be final as I was planning to test it in different maps when doing #103, but never did 😢);
- Switches the small new areas drawing to `DebugDrawNavBox` so that even the tiny new areas show up (note that new areas can always be differentiated from areas that have the 3 rgb components on by checking the surrounding context).