### PR TITLE
Rainy Infected Variants Update

### DIFF
--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_burning.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded_burning.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded_burning.vmt
@@ -1,0 +1,13 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp.vmt
@@ -4,5 +4,8 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$DETAIL "models/infected/common/l4d2/detail/ci_detail_algae"
+$DETAILSCALE 6
+$phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp.vmt
@@ -1,0 +1,8 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_burning.vmt
@@ -1,0 +1,9 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_burning.vmt
@@ -4,6 +4,9 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$DETAIL "models/infected/common/l4d2/detail/ci_detail_algae"
+$DETAILSCALE 6
+$phongboost 2
 $BURNING 1
 }
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded.vmt
@@ -1,0 +1,9 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded.vmt
@@ -4,6 +4,9 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$DETAIL "models/infected/common/l4d2/detail/ci_detail_algae"
+$DETAILSCALE 6
+$phongboost 2
 $WOUNDED 1
 }
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded_burning.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_swamp_wounded_burning.vmt
@@ -4,6 +4,9 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_swamp"
+$DETAIL "models/infected/common/l4d2/detail/ci_detail_algae"
+$DETAILSCALE 6
+$phongboost 2
 $WOUNDED 1
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain.vmt
@@ -1,0 +1,18 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$EYEGLOWCOLOR "[2 2 2]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain.vmt
@@ -5,8 +5,8 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$detailscale 2
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"
 $phongboost 1

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_burning.vmt
@@ -5,8 +5,8 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$detailscale 2
 $EYEGLOW 1
 $BURNING 1
 $EYEGLOWCOLOR "[2 2 2]"

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_burning.vmt
@@ -1,0 +1,15 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$EYEGLOW 1
+$BURNING 1
+$EYEGLOWCOLOR "[2 2 2]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded.vmt
@@ -1,0 +1,15 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$EYEGLOW 1
+$EYEGLOWCOLOR "[2 2 2]"
+$EYEGLOWFLASHLIGHTBOOST 10
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded.vmt
@@ -5,8 +5,8 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$detailscale 2
 $EYEGLOW 1
 $EYEGLOWCOLOR "[2 2 2]"
 $EYEGLOWFLASHLIGHTBOOST 10

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded_burning.vmt
@@ -5,8 +5,8 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$detailscale 2
 $EYEGLOW 1
 $EYEGLOWCOLOR "[.5 .5 .5]"
 $EYEGLOWFLASHLIGHTBOOST 1000

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded_burning.vmt
@@ -1,0 +1,16 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
+$EYEGLOW 1
+$EYEGLOWCOLOR "[.5 .5 .5]"
+$EYEGLOWFLASHLIGHTBOOST 1000
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_burning.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded_burning.vmt
@@ -1,0 +1,13 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded_burning.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_burning.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded_burning.vmt
@@ -5,7 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
-$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded_burning.vmt
@@ -1,0 +1,13 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
+$detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}


### PR DESCRIPTION
Updates all Rainy infected .vmt variants to use correct phong, detail scale, and color gradient. The Rainy variants will now be consistent with the Normal and Swamp infected .vmt variants.

Also  updates the unused "cif_tanktop_jeans_swamp.vmt" to be consistent with other swamp variants. The "cif_tanktop_jeans_swamp.vtf" file is missing, because it was never completed. However, if it is ever created it will be fully functional.