### PR TITLE
Enforce correct type for boolean Director options

### DIFF
--- a/root/scripts/vscripts/community1.nut
+++ b/root/scripts/vscripts/community1.nut
@@ -68,7 +68,7 @@ MutationOptions <-
 		}
 		return 0;
 	}
-	
+
 	DefaultItems =
 	[
 		"weapon_pistol_magnum",
@@ -110,7 +110,7 @@ function LeftSafeAreaThink()
 	{
 		if ( NetProps.GetPropInt( player, "m_iTeamNum" ) != 2 )
 			continue;
-		
+
 		if ( ResponseCriteria.GetValue( player, "instartarea" ) == "0" )
 		{
 			SessionOptions.cm_MaxSpecials = 8;
@@ -125,7 +125,7 @@ function OnGameEvent_round_start_post_nav( params )
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
 	{
 		local population = NetProps.GetPropString( spawner, "m_szPopulation" );
-		
+
 		if ( population == "boomer" || population == "hunter" || population == "smoker" || population == "jockey"
 			|| population == "charger" || population == "spitter" || population == "new_special" || population == "church"
 				|| population == "tank" || population == "witch" || population == "witch_bride" || population == "river_docks_trap" )
@@ -133,7 +133,7 @@ function OnGameEvent_round_start_post_nav( params )
 		else
 			spawner.Kill();
 	}
-	
+
 	if ( Director.GetMapName() == "c1m1_hotel" )
 		DirectorOptions.cm_TankLimit <- 0;
 	else if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
@@ -147,7 +147,7 @@ function OnGameEvent_player_left_safe_area( params )
 	local player = GetPlayerFromUserID( params["userid"] );
 	if ( !player )
 		return;
-	
+
 	if ( ResponseCriteria.GetValue( player, "instartarea" ) == "1" )
 	{
 		SessionOptions.cm_MaxSpecials = 0;
@@ -163,7 +163,7 @@ function OnGameEvent_triggered_car_alarm( params )
 		ZSpawn( { type = 8 } );
 		DirectorOptions.cm_AggressiveSpecials = false;
 	}
-	
+
 	StartAssault();
 }
 
@@ -182,16 +182,16 @@ function OnGameEvent_gauntlet_finale_start( params )
 function OnGameEvent_player_spawn( params )
 {
 	local player = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( ( !player ) || ( player.IsSurvivor() ) )
 		return;
-	
+
 	local zombieType = player.GetZombieType();
 	if ( zombieType > 6 )
 		return;
-	
+
 	local modelName = player.GetModelName();
-	
+
 	if ( !SessionState.ModelCheck[ zombieType - 1 ] )
 	{
 		if ( (zombieType == 2) && !("community1_no_female_boomers" in getroottable()) )
@@ -206,17 +206,17 @@ function OnGameEvent_player_spawn( params )
 		}
 		else
 			SessionState.ModelCheck[ zombieType - 1 ] = true;
-		
+
 		if ( SessionState.SIModelsBase[zombieType - 1].find( modelName ) == null )
 		{
 			SessionState.SIModelsBase[zombieType - 1].append( modelName );
 			SessionState.SIModels[zombieType - 1].append( modelName );
 		}
 	}
-	
+
 	if ( SessionState.SIModelsBase[zombieType - 1].len() == 1 )
 		return;
-	
+
 	local zombieModels = SessionState.SIModels[zombieType - 1];
 	if ( zombieModels.len() == 0 )
 		SessionState.SIModels[zombieType - 1].extend( SessionState.SIModelsBase[zombieType - 1] );
@@ -226,11 +226,11 @@ function OnGameEvent_player_spawn( params )
 		zombieModels.remove( foundModel );
 		return;
 	}
-	
+
 	local randomElement = RandomInt( 0, zombieModels.len() - 1 );
 	local randomModel = zombieModels[ randomElement ];
 	zombieModels.remove( randomElement );
-	
+
 	player.SetModel( randomModel );
 }
 

--- a/root/scripts/vscripts/community2.nut
+++ b/root/scripts/vscripts/community2.nut
@@ -23,7 +23,7 @@ DirectorOptions <-
 	// convert items that aren't useful
 	weaponsToConvert =
 	{
-		weapon_vomitjar = 	"weapon_molotov_spawn"
+		weapon_vomitjar = "weapon_molotov_spawn"
 	}
 
 	function ConvertWeaponSpawn( classname )
@@ -41,7 +41,7 @@ function OnGameEvent_round_start_post_nav( params )
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
 	{
 		local population = NetProps.GetPropString( spawner, "m_szPopulation" );
-		
+
 		if ( population == "boomer" || population == "spitter" || population == "church" || population == "river_docks_trap" )
 			continue;
 		else

--- a/root/scripts/vscripts/community3.nut
+++ b/root/scripts/vscripts/community3.nut
@@ -1,0 +1,23 @@
+Msg("Activating community mutation 3.\n");
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+	
+	cm_CommonLimit = 0
+	
+	BoomerLimit = 0
+	ChargerLimit = 0
+	HunterLimit = 0
+	JockeyLimit = 4
+	SmokerLimit = 0
+	SpitterLimit = 0
+	cm_MaxSpecials = 4
+	
+	cm_SpecialRespawnInterval = 20
+	
+	function ConvertZombieClass(id)
+	{
+		return 5;
+	}
+}

--- a/root/scripts/vscripts/community3.nut
+++ b/root/scripts/vscripts/community3.nut
@@ -3,9 +3,9 @@ Msg("Activating community mutation 3.\n");
 DirectorOptions <-
 {
 	ActiveChallenge = 1
-	
+
 	cm_CommonLimit = 0
-	
+
 	BoomerLimit = 0
 	ChargerLimit = 0
 	HunterLimit = 0
@@ -13,9 +13,9 @@ DirectorOptions <-
 	SmokerLimit = 0
 	SpitterLimit = 0
 	cm_MaxSpecials = 4
-	
+
 	cm_SpecialRespawnInterval = 20
-	
+
 	function ConvertZombieClass(id)
 	{
 		return 5;

--- a/root/scripts/vscripts/community4.nut
+++ b/root/scripts/vscripts/community4.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Nightmare\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -18,6 +17,5 @@ DirectorOptions <-
 	SurvivorMaxIncapacitatedCount = 3
 	SpecialInitialSpawnDelayMin = 5
 	SpecialInitialSpawnDelayMax = 30
-	TankHitDamageModifierCoop = 0.25	
+	TankHitDamageModifierCoop = 0.25
 }
-

--- a/root/scripts/vscripts/community4.nut
+++ b/root/scripts/vscripts/community4.nut
@@ -1,0 +1,23 @@
+//-----------------------------------------------------
+Msg("Activating Nightmare\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	cm_DominatorLimit = 8
+	cm_MaxSpecials = 8
+	cm_SpecialRespawnInterval = 30
+	cm_AutoReviveFromSpecialIncap = 1
+	cm_AllowPillConversion = 0
+	cm_TankLimit = 4
+	ProhibitBosses = 0
+
+	BoomerLimit = 0
+	SurvivorMaxIncapacitatedCount = 3
+	SpecialInitialSpawnDelayMin = 5
+	SpecialInitialSpawnDelayMax = 30
+	TankHitDamageModifierCoop = 0.25	
+}
+

--- a/root/scripts/vscripts/community4.nut
+++ b/root/scripts/vscripts/community4.nut
@@ -9,10 +9,10 @@ DirectorOptions <-
 	cm_DominatorLimit = 8
 	cm_MaxSpecials = 8
 	cm_SpecialRespawnInterval = 30
-	cm_AutoReviveFromSpecialIncap = 1
-	cm_AllowPillConversion = 0
+	cm_AutoReviveFromSpecialIncap = true
+	cm_AllowPillConversion = false
 	cm_TankLimit = 4
-	ProhibitBosses = 0
+	ProhibitBosses = false
 
 	BoomerLimit = 0
 	SurvivorMaxIncapacitatedCount = 3

--- a/root/scripts/vscripts/community5.nut
+++ b/root/scripts/vscripts/community5.nut
@@ -2,7 +2,6 @@
 Msg("Activating Death's Door\n");
 Msg("Made by Rayman1103\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -16,7 +15,7 @@ DirectorOptions <-
 	{
 		if ( classname == "weapon_first_aid_kit" )
 			return false;
-		
+
 		return true;
 	}
 
@@ -63,10 +62,10 @@ DirectorOptions <-
 function OnGameEvent_player_hurt_concise( params )
 {
 	local player = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( (!player) || (!player.IsSurvivor()) )
 		return;
-	
+
 	if ( NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 0 && player.GetHealth() < (player.GetMaxHealth() / 4) )
 	{
 		player.SetReviveCount( 0 );
@@ -79,7 +78,7 @@ function CheckHealthAfterLedgeHang( userid )
 	local player = GetPlayerFromUserID( userid );
 	if ( (!player) || (!player.IsSurvivor()) )
 		return;
-	
+
 	if ( player.GetHealth() < (player.GetMaxHealth() / 4) )
 	{
 		player.SetReviveCount( 0 );
@@ -90,10 +89,10 @@ function CheckHealthAfterLedgeHang( userid )
 function OnGameEvent_revive_success( params )
 {
 	local player = GetPlayerFromUserID( params["subject"] );
-	
+
 	if ( (!params["ledge_hang"]) || (!player) || (!player.IsSurvivor()) )
 		return;
-	
+
 	if ( NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 0 )
 		EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.CheckHealthAfterLedgeHang(" + params["subject"] + ")", 0.1 );
 }
@@ -101,10 +100,10 @@ function OnGameEvent_revive_success( params )
 function OnGameEvent_bot_player_replace( params )
 {
 	local player = GetPlayerFromUserID( params["player"] );
-	
+
 	if ( (!player) || (NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 1) )
 		return;
-	
+
 	StopSoundOn( "Player.Heartbeat", player );
 }
 

--- a/root/scripts/vscripts/dash.nut
+++ b/root/scripts/vscripts/dash.nut
@@ -1,0 +1,460 @@
+////////////////////////////////
+// "Dash" is another extended mutation demo mode to show some of the capabilities available in script
+//
+// the players must run near a sequence of waypoints (well, ok, lampposts) in order
+// As they reach each one, we light up the next one, and also summon a new panic wave from the next locale
+// Designers use the Entity Placement tool to lay down a sequence of waypoints
+// Waypoint naming:
+// If you name your waypoints sequentially, e.g., waypoint_001, waypoint_002 flagpole waypoints will be used.
+// See scripted_c5m2_park_dash.nut, c5m2_park_entities_dash.txt for an example.
+//
+// If you prefix your waypoints with "short_" e.g., short_waypoint_001, short_waypoint_002, then shorter
+// waypoints will be used.
+// See scripted_c5m4_quarter_dash.nut, c5m4_quarter_entities_dash.txt for an example.
+//
+// When survivors reach the final waypoint, we do a TANK wave, and they get a final time based on when they finish
+// 
+// The waypoint itself has a fairly big script to detect nearby players, and track which ones have reached it
+//   as well as to trigger visual indications of progress, and "waypoint finished" calls back to this script
+// And this script on startup has to sort the waypoints to make the in-order list
+
+// printl(" Loading Dash mode")
+
+MutationOptions <-
+{   
+	// since we are going to move the spawn point to "ahead" on the track as we hit waypoints
+	PreferredMobDirection = SPAWN_NEAR_POSITION
+	PreferredMobPositionRange = 600
+
+	// we should change this to zero
+	PreferredMobPosition = Vector( 0,0,0 )
+
+	SpawnSetRule = SPAWN_POSITIONAL
+	SpawnSetRadius = 2000
+	SpawnSetPosition = Vector( -7150, -3647, -97 )
+
+	WanderingZombieDensityModifier = 0 // get rid of wanderers
+
+	cm_ShouldEscortHumanPlayers = 1
+	cm_AggressiveSpecials = 1
+
+	BoomerLimit  = 0
+	ChargerLimit = 0
+	HunterLimit  = 0
+	JockeyLimit  = 0
+	SpitterLimit = 0
+	SmokerLimit  = 0
+	MaxSpecials  = 0
+	CommonLimit  = 20
+	MegaMobSize	 = 20
+	TankLimit    = 0
+	WitchLimit	 = 0
+
+	function EndScriptedMode()
+	{
+		local finished = true;
+		foreach ( val in g_RoundState.WaypointList )
+		{
+			if ( val.GetScriptScope().active == true )
+			{
+				finished = false
+				break;
+			}
+		}
+
+		if ( finished )
+		{
+			// Finished the course
+			return 0 // SCENARIO_RESTART
+		}
+		else
+		{
+			return 1 // SCENARIO_SURVIVORS_DEAD
+		}
+	}
+
+	/*  Not using this method anymore
+	function GetScoreboardFilename( endreason )
+	{
+		switch ( endreason )
+		{
+			case 1:
+				return "Resource/UI/scriptedmodeplaceholderlost.res"
+			case 0:
+				return "Resource/UI/scriptedmodeplaceholderwon.res"
+			default:
+				return "Resource/UI/scriptedmodeplaceholder.res"
+		}
+	}
+	*/
+
+	// challenge mode experiment - make sure old CM type stuff works fine in new mutation code
+	cm_HeadshotOnly = 0
+
+	DefaultItems =
+	[
+		"weapon_rifle_m60",
+		"weapon_pistol_magnum",
+		"adrenaline",
+		"pipe_bomb"
+	]
+
+	// Set characters up with default items
+	function GetDefaultItem( idx )
+	{
+		if ( idx < DefaultItems.len() )
+		{
+			return DefaultItems[idx];
+		}
+		return 0;
+	}	
+}
+
+// SessionState for this mode - mostly about the waypoint tracking/which on next/etc/etc
+MutationState <-
+{
+	StartActive = true	
+	CurrentWaypoint = 0
+	FinalWaypoint = 0
+	JustHitWaypoint = false
+	YouWon = false
+	FirstWaypointHit = false
+	TimerWaypoint = 0   // for a soon to be written more flexible setup
+	MobWaypoint = 0
+	CommonIncrement = 0
+}
+
+// callback for waypoint generation - as we spawn each one we add it to the list
+function SetWaypointCB( waypointObj, rarity )
+{
+	local waypointScr = waypointObj.GetScriptScope()
+	waypointScr.myID <- g_ModeScript.MutationState.FinalWaypoint++
+
+	
+	// if we're using a custom list set the initial touch count on this waypoint
+	if( "CustomWaypointList" in g_MapScript )
+		waypointScr.initialTouchCount = g_MapScript.CustomWaypointList[ g_RoundState.WaypointList.len() ].startingTouchCount
+
+	g_RoundState.WaypointList.append(waypointObj)
+}
+
+// the startbox needs a custom precache function if you are using it
+function Precache()
+{
+	Startbox_Precache()
+}
+
+// called on startup - setup a few callbacks if they arent there
+// and then go ahead and teleport players to start, spawn the startbox, activate first waypoint
+function OnGameplayStart()
+{
+	CheckOrSetMapCallback( "MapOverrideOptions", @() false )
+	CheckOrSetMapCallback( "MapGameplayStart", @() false )
+
+	Scoring_LoadTable( SessionState.MapName, SessionState.ModeName )
+
+	//teleport players to the start point
+	if (!TeleportPlayersToStartPoints( "gamemode_playerstart" ) )
+		printl(" ** TeleportPlayersToStartPoints: Spawn point count or player count incorrect! Verify that there are 4 of each.")
+
+	// create a start box
+	if ( !SpawnStartBox( "startbox_origin" ) )
+	{
+		printl("Note: SpawnStartBox() called but there is no startbox_origin in map.")
+	}
+
+	// If the map script supplies a CustomWaypointList of points spawn the entities in that order
+	if( "CustomWaypointList" in g_MapScript )
+	{
+		SpawnCustomWaypointList()
+	}
+	else
+	{
+		// Spawn waypoints in order
+		SortAndSpawnWaypointList()
+	}
+
+	if (g_RoundState.WaypointList.len() > 0)
+	{
+		EntFire( g_RoundState.WaypointList[0].GetName(), "StartGlowing" )
+		EntFire( g_RoundState.WaypointList[0].GetName(), "fireuser1" )
+		g_RoundState.WaypointList[0].GetScriptScope().active = true
+		SessionOptions.PreferredMobPosition = g_RoundState.WaypointList[0].GetOrigin()
+	}
+
+	SessionOptions.ScriptedStageType = STAGE_SETUP
+	SessionOptions.ScriptedStageValue = 1000
+
+	MapGameplayStart()
+}
+
+//=========================================================
+// Uses the CustomWaypointList defined in the map script to
+// spawn waypoints.  The info_item_position entities are
+// collected in the order they appear in the list and then
+// the waypoints are spawned in that order.
+//=========================================================
+function SpawnCustomWaypointList()
+{
+	// collect the info_item_position entities into a list
+	local currentEnt  = null
+	local tempWaypointList = []
+
+	foreach( idx, val in CustomWaypointList )
+	{
+		currentEnt = Entities.FindByName( null, val.targetName )
+		
+		// store the waypoint if we found it, otherwise complain
+		if( currentEnt )
+		{
+			tempWaypointList.append( currentEnt )
+		}
+		else
+		{
+			printl( " ** Waypoint Spawn ERROR**  I can't find the waypoint named: " + val.targetName )
+		}
+	}
+
+	SpawnWaypointList( tempWaypointList )
+}
+
+//=========================================================
+// Collect all the info_item_position entities that are named 
+// "short_waypoint_*" OR "waypoint_*", put them into a list
+// and sort it by suffix.  This will allow us to spawn all
+// the waypoints in order so they can know their touch order
+//=========================================================
+function SortAndSpawnWaypointList()
+{
+	local currentWaypoint = Entities.FindByClassname( null, "info_item_position" )
+	local tempWaypointList = []
+
+	while( currentWaypoint )
+	{
+		local name = currentWaypoint.GetName()
+		if( ( name.find( "waypoint_" ) == 0 ) || ( name.find( "short_waypoint_" ) == 0 ) )
+		{
+			tempWaypointList.append( currentWaypoint )
+		}
+
+		currentWaypoint = Entities.FindByClassname( currentWaypoint, "info_item_position" )
+	}
+
+	// sort the list by suffix	
+	tempWaypointList.sort(@(a,b) a.GetName().slice(-4) <=> b.GetName().slice(-4) )
+
+	SpawnWaypointList( tempWaypointList )
+}
+
+//=========================================================
+// Spawn the provided list of waypoints on their positions
+//=========================================================
+function SpawnWaypointList( list )
+{
+	local waypointGroup = g_MapScript.GetEntityGroup( "DashWaypoint" )
+	local shortWaypointGroup = g_MapScript.GetEntityGroup( "DashWaypointShort" )
+
+	// set callbacks
+	shortWaypointGroup.SpawnTables[ "waypoint" ].PostPlaceCB <- SetWaypointCB
+	waypointGroup.SpawnTables[ "waypoint" ].PostPlaceCB <- SetWaypointCB
+
+	// spawn the waypoints	
+	foreach( idx, ent in list )
+	{
+		// does our waypoint start with "short_"?  If so, it is a short waypoint! Spawn it.
+		if( ent.GetName().find( "short_" ) == 0  )
+		{
+			SpawnSingleAt( shortWaypointGroup, ent.GetOrigin(), ent.GetAngles() )
+		}
+		else // assuming it must be a normal waypoint since it isn't "short_"
+		{
+			SpawnSingleAt( waypointGroup, ent.GetOrigin(), ent.GetAngles() )
+		}
+	}
+}
+
+function DashDisplayScores( )
+{
+	local final_time = HUDReadTimer(1)
+	local score_strings = Scoring_AddScoreAndBuildStrings( Scoring_MakeName(), final_time )
+	HUDPlace( HUD_TICKER, 0.32, 0.27, 0.36, 0.20 )
+	HUDPlace( HUD_FAR_RIGHT, 0.28, 0.50, 0.44, 0.06 )
+	HUDPlace( HUD_FAR_LEFT,  0.28, 0.58, 0.44, 0.06 )
+	HUDPlace( HUD_LEFT_BOT,  0.28, 0.66, 0.44, 0.06 )
+	HUDPlace( HUD_RIGHT_BOT, 0.28, 0.74, 0.44, 0.06 )
+	local ticker_str = score_strings.yourtime
+	if ("finish" in score_strings)
+		ticker_str = ticker_str + "\n" + score_strings.finish
+	ticker_str = ticker_str + "\nBest Times So Far"
+	Ticker_SetBlink( false )   // or true if you came in first? hmmm....
+	Ticker_NewStr( ticker_str, 120 )
+	foreach (idx, val in score_strings.topscores)
+	{
+		local hudfield = "score"+(idx+1)
+		DashHUD.Fields[hudfield].dataval = val
+		DashHUD.Fields[hudfield].flags = DashHUD.Fields[hudfield].flags & ~HUD_FLAG_NOTVISIBLE
+	}
+	Scoring_SaveTable( SessionState.MapName, SessionState.ModeName )
+}
+
+// this array holds the waypoints in order, up to SessionState.FinalWaypoint (though really, could just use len() for safety?
+g_RoundState.WaypointList <- []
+
+// called at basically each waypoint via ForceNextStage - or when a PANIC ends we just go to a delay
+function GetNextStage()
+{
+	smDbgPrint("GetNextStage called")
+
+	if ( SessionState.YouWon )
+	{
+		smDbgPrint("Really winningz, going to rezultz, yo!")
+		SessionOptions.ScriptedStageType = STAGE_RESULTS
+		SessionOptions.ScriptedStageValue = 10
+		DashDisplayScores()
+	}
+	else if ( SessionState.JustHitWaypoint && SessionState.FinalWaypoint > 0 )
+	{	
+		if ( !SessionState.FirstWaypointHit ) // could be start line, or waypoint 0
+		{  // hit firstone, kick things off
+			smDbgPrint("Hit First Waypoint!")
+			SessionState.FirstWaypointHit = true
+			HUDManageTimers( 1 , TIMER_COUNTUP, 0)   // generalize this?
+
+			// calculate the number of common infected to add each time a waypoint is completed
+			SessionState.CommonIncrement = (100 - SessionOptions.CommonLimit) / SessionState.FinalWaypoint
+		}  
+		
+		if( !MapOverrideOptions() )
+		{
+			// really, do we need this? or can we just always do panic here else a delay???
+			local PercentageComplete = SessionState.CurrentWaypoint * 1.0 / SessionState.FinalWaypoint
+		
+			SessionState.JustHitWaypoint = false
+			SessionOptions.ScriptedStageType = STAGE_PANIC
+			SessionOptions.ScriptedStageValue = 1
+			foreach (val in SpecialNames)
+			{
+				local limit = RandomInt(1,3) + PercentageComplete * 3
+				SessionOptions[val + "Limit"] = limit
+			}
+			SessionOptions.MaxSpecials = RandomInt(2,6) + PercentageComplete * 3
+			if (SessionOptions.CommonLimit < 100)
+				SessionOptions.CommonLimit += SessionState.CommonIncrement
+
+			if (SessionOptions.MegaMobSize < 50 )
+				SessionOptions.MegaMobSize += SessionState.CommonIncrement
+
+			if (SessionState.CurrentWaypoint == SessionState.FinalWaypoint - 1 )
+			{
+				Ticker_NewStr("One gate to go!")
+				SessionOptions.TankLimit = 1 // how do i force a tank from script?
+				SessionOptions.ScriptedStageType = STAGE_ESCAPE  // i guess i do an escape stage
+			}
+			else // display some help text on the ticker
+			{
+				switch( SessionState.CurrentWaypoint )
+				{
+					case 1:
+						Ticker_NewStr( "Each time you activate a new waypoint more infected will attack.", 15 )
+						break
+					
+					case 2:
+						Ticker_NewStr( "You cleared the waypoint! Here come more infected!", 15 )
+						break
+				}
+			}
+		}
+	}
+	else
+	{
+		SessionOptions.ScriptedStageType = STAGE_DELAY
+		SessionOptions.ScriptedStageValue = 1000
+		SessionOptions.MaxSpecials = 0
+	}
+
+	smDbgPrint("Dash setting Mode " + SessionOptions.ScriptedStageType + " val " + SessionOptions.ScriptedStageValue)
+
+	// we also want to positionally spawn at the mob target - though really i'd like to do some distance/scale stuff, too
+	SessionOptions.SpawnSetPosition = SessionOptions.PreferredMobPosition
+}
+
+// because call DWD is where we active/deactive the waypoints, we can just treat the start line as secret pre-waypoint
+function SurvivorLeftStartBox()
+{
+	SessionState.JustHitWaypoint = true   // and since the main loop never looks up into the array, that is o.k.
+	Director.ForceNextStage()
+}
+
+// each time a waypoint is hit this is called to get us moving forward
+// i.e. we need to activate the next waypoint, see if it is the final one, track counts, and so on
+function DashWaypointDone( id )
+{
+	smDbgPrint("Dash Waypoint finished! " + id)
+
+	// sanity check!
+	if ( id != SessionState.CurrentWaypoint )
+		printl("Hey! you think you are done with waypoint " + id + " but current is " + SessionState.CurrentWaypoint )
+
+	EntFire( g_RoundState.WaypointList[id].GetName(), "StopGlowing" )
+	g_RoundState.WaypointList[id].GetScriptScope().active = false
+	// printl( "Deactivated waypoint " + id )
+	local next_id = ++SessionState.CurrentWaypoint
+	if ( next_id >= SessionState.FinalWaypoint )
+	{
+		// printl("Youz da Winner, yo!")
+		SessionState.CurrentWaypoint--   // for safety
+		SessionState.YouWon = true
+
+		// stop the clock
+		HUDManageTimers( 1, TIMER_STOP, 0 )
+	}
+	else
+	{
+		EntFire( g_RoundState.WaypointList[next_id].GetName(), "StartGlowing" )
+		EntFire( g_RoundState.WaypointList[next_id].GetName(), "fireuser1" )
+		//printl("Moving on to next waypoint " + next_id )
+		g_RoundState.WaypointList[next_id].GetScriptScope().active = true
+		SessionOptions.PreferredMobPosition = g_RoundState.WaypointList[next_id].GetOrigin()
+	}
+	SessionState.JustHitWaypoint = true
+	Director.ForceNextStage()
+}
+
+// add Criteria for the new Response Rule speech criteria system
+// i.e. this is to add data to the RR table the characters use to choose statements
+function AddCriteria( criteriaTable )
+{
+	criteriaTable.PercentComplete <- SessionState.FinalWaypoint > 0 ? (SessionState.CurrentWaypoint*1.0)/SessionState.FinalWaypoint : 0
+//	printl("Dash AddCriteria added " + criteriaTable.PercentComplete)
+}
+
+//-------------------------------------------------------
+// Include all entity group interfaces needed for this mode
+//-------------------------------------------------------
+IncludeScript( "entitygroups/dash_waypoint_group" )
+IncludeScript( "entitygroups/dash_waypoint_short_group" )
+
+DashHUD <- {}
+
+// HUD setup/control - our HUD is pretty simple in dash
+function SetupModeHUD( )
+{
+	DashHUD =
+	{
+		Fields = 
+		{
+			waypoint = { slot = HUD_RIGHT_TOP, name = "waypoint", staticstring = "Waypoint: ", datafunc = @() SessionState.CurrentWaypoint },
+			timer    = { slot = HUD_LEFT_TOP, name = "timer", staticstring = "Time: ", special = HUD_SPECIAL_TIMER1 },
+
+			// this is kinda a lie! we are really going to move these w/HUDPlace for displaying final scores!
+			// we will move the Ticker down to be a "header" - then need 4 slots for top 4
+			score1   = { slot = HUD_FAR_RIGHT, name = "score1", dataval = "Score1", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+			score2   = { slot = HUD_FAR_LEFT,  name = "score2", dataval = "Score2", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+			score3   = { slot = HUD_LEFT_BOT,  name = "score3", dataval = "Score3", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+			score4   = { slot = HUD_RIGHT_BOT, name = "score4", dataval = "Score4", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+		}
+	}
+
+	Ticker_AddToHud( DashHUD, "Hurry past the poles, go for a best time" )
+	HUDSetLayout( DashHUD )
+}

--- a/root/scripts/vscripts/dash.nut
+++ b/root/scripts/vscripts/dash.nut
@@ -35,8 +35,8 @@ MutationOptions <-
 
 	WanderingZombieDensityModifier = 0 // get rid of wanderers
 
-	cm_ShouldEscortHumanPlayers = 1
-	cm_AggressiveSpecials = 1
+	cm_ShouldEscortHumanPlayers = true
+	cm_AggressiveSpecials = true
 
 	BoomerLimit  = 0
 	ChargerLimit = 0
@@ -89,7 +89,7 @@ MutationOptions <-
 	*/
 
 	// challenge mode experiment - make sure old CM type stuff works fine in new mutation code
-	cm_HeadshotOnly = 0
+	cm_HeadshotOnly = false
 
 	DefaultItems =
 	[

--- a/root/scripts/vscripts/dash.nut
+++ b/root/scripts/vscripts/dash.nut
@@ -13,7 +13,7 @@
 // See scripted_c5m4_quarter_dash.nut, c5m4_quarter_entities_dash.txt for an example.
 //
 // When survivors reach the final waypoint, we do a TANK wave, and they get a final time based on when they finish
-// 
+//
 // The waypoint itself has a fairly big script to detect nearby players, and track which ones have reached it
 //   as well as to trigger visual indications of progress, and "waypoint finished" calls back to this script
 // And this script on startup has to sort the waypoints to make the in-order list
@@ -21,7 +21,7 @@
 // printl(" Loading Dash mode")
 
 MutationOptions <-
-{   
+{
 	// since we are going to move the spawn point to "ahead" on the track as we hit waypoints
 	PreferredMobDirection = SPAWN_NEAR_POSITION
 	PreferredMobPositionRange = 600
@@ -46,9 +46,9 @@ MutationOptions <-
 	SmokerLimit  = 0
 	MaxSpecials  = 0
 	CommonLimit  = 20
-	MegaMobSize	 = 20
+	MegaMobSize  = 20
 	TankLimit    = 0
-	WitchLimit	 = 0
+	WitchLimit   = 0
 
 	function EndScriptedMode()
 	{
@@ -107,13 +107,13 @@ MutationOptions <-
 			return DefaultItems[idx];
 		}
 		return 0;
-	}	
+	}
 }
 
 // SessionState for this mode - mostly about the waypoint tracking/which on next/etc/etc
 MutationState <-
 {
-	StartActive = true	
+	StartActive = true
 	CurrentWaypoint = 0
 	FinalWaypoint = 0
 	JustHitWaypoint = false
@@ -130,7 +130,6 @@ function SetWaypointCB( waypointObj, rarity )
 	local waypointScr = waypointObj.GetScriptScope()
 	waypointScr.myID <- g_ModeScript.MutationState.FinalWaypoint++
 
-	
 	// if we're using a custom list set the initial touch count on this waypoint
 	if( "CustomWaypointList" in g_MapScript )
 		waypointScr.initialTouchCount = g_MapScript.CustomWaypointList[ g_RoundState.WaypointList.len() ].startingTouchCount
@@ -203,7 +202,7 @@ function SpawnCustomWaypointList()
 	foreach( idx, val in CustomWaypointList )
 	{
 		currentEnt = Entities.FindByName( null, val.targetName )
-		
+
 		// store the waypoint if we found it, otherwise complain
 		if( currentEnt )
 		{
@@ -219,7 +218,7 @@ function SpawnCustomWaypointList()
 }
 
 //=========================================================
-// Collect all the info_item_position entities that are named 
+// Collect all the info_item_position entities that are named
 // "short_waypoint_*" OR "waypoint_*", put them into a list
 // and sort it by suffix.  This will allow us to spawn all
 // the waypoints in order so they can know their touch order
@@ -240,7 +239,7 @@ function SortAndSpawnWaypointList()
 		currentWaypoint = Entities.FindByClassname( currentWaypoint, "info_item_position" )
 	}
 
-	// sort the list by suffix	
+	// sort the list by suffix
 	tempWaypointList.sort(@(a,b) a.GetName().slice(-4) <=> b.GetName().slice(-4) )
 
 	SpawnWaypointList( tempWaypointList )
@@ -258,7 +257,7 @@ function SpawnWaypointList( list )
 	shortWaypointGroup.SpawnTables[ "waypoint" ].PostPlaceCB <- SetWaypointCB
 	waypointGroup.SpawnTables[ "waypoint" ].PostPlaceCB <- SetWaypointCB
 
-	// spawn the waypoints	
+	// spawn the waypoints
 	foreach( idx, ent in list )
 	{
 		// does our waypoint start with "short_"?  If so, it is a short waypoint! Spawn it.
@@ -313,7 +312,7 @@ function GetNextStage()
 		DashDisplayScores()
 	}
 	else if ( SessionState.JustHitWaypoint && SessionState.FinalWaypoint > 0 )
-	{	
+	{
 		if ( !SessionState.FirstWaypointHit ) // could be start line, or waypoint 0
 		{  // hit firstone, kick things off
 			smDbgPrint("Hit First Waypoint!")
@@ -322,13 +321,13 @@ function GetNextStage()
 
 			// calculate the number of common infected to add each time a waypoint is completed
 			SessionState.CommonIncrement = (100 - SessionOptions.CommonLimit) / SessionState.FinalWaypoint
-		}  
-		
+		}
+
 		if( !MapOverrideOptions() )
 		{
 			// really, do we need this? or can we just always do panic here else a delay???
 			local PercentageComplete = SessionState.CurrentWaypoint * 1.0 / SessionState.FinalWaypoint
-		
+
 			SessionState.JustHitWaypoint = false
 			SessionOptions.ScriptedStageType = STAGE_PANIC
 			SessionOptions.ScriptedStageValue = 1
@@ -357,7 +356,7 @@ function GetNextStage()
 					case 1:
 						Ticker_NewStr( "Each time you activate a new waypoint more infected will attack.", 15 )
 						break
-					
+
 					case 2:
 						Ticker_NewStr( "You cleared the waypoint! Here come more infected!", 15 )
 						break
@@ -441,7 +440,7 @@ function SetupModeHUD( )
 {
 	DashHUD =
 	{
-		Fields = 
+		Fields =
 		{
 			waypoint = { slot = HUD_RIGHT_TOP, name = "waypoint", staticstring = "Waypoint: ", datafunc = @() SessionState.CurrentWaypoint },
 			timer    = { slot = HUD_LEFT_TOP, name = "timer", staticstring = "Time: ", special = HUD_SPECIAL_TIMER1 },

--- a/root/scripts/vscripts/holdout.nut
+++ b/root/scripts/vscripts/holdout.nut
@@ -1,0 +1,495 @@
+///////////////////////////////////////////////////////////////////////////////
+// The Holdout game mode! Brought to you by the new Mutation system!
+// A Holdout Is...
+//   Mostly a demo of the new mutation system, but a game mode as well
+//   A Continuous cycle of attack/cooldown/attack/cooldown
+//   in code, implemented as 3 phases
+//        PANIC - spawn some enemies around the players
+//        CLEAROUT - wait until the enemies are (mostly) all gone
+//        DELAY - a cooldown time before the next wave of enemies
+// There are several "special behaviors" as this happens
+//   The Escape wave can happen at a specified wave #, or as a result of in game action (timer running down, for instance)
+//   There can be special events that take over based on the current Stage #
+
+// This is a very Structured mode - it uses stagetables and other "helpers" in the mutation system
+// You dont need to use these in your own mutations, though you are of course welcome to
+
+// as a map, you should go implement the following functions, returning a "stageTable"
+// or null to ignore
+//   DoMapEventCheck()
+//   DoMapSetup()
+//   GetMapEscapeStage()
+//   IsMapSpecificStage()    // dont like this! potential out of sync/parallel variables
+//   GetMapSpecificStage()   //    maybe IsMap sets a "stageSpecific" that GetMap can use?
+//   GetAttackStage()
+//   GetMapClearoutStage()
+//   GetMapDelayStage()
+///////////////////////////////////////////////////////////////////////////////
+
+//---------------------------------------------------------
+// This is the SessionState - any non-director data all your session code wants to be able to look at
+// So we hold data about what wave, some UI controls, and info about managing warnings
+MutationState <-
+{
+	HUDWaveInfo = true           // do you want the Wave # in middle of UI
+	HUDRescueTimer = false       // or would you rather have the rescue timer (cant have both)
+	HUDTickerText = "Holdout as long as you can"
+	RescueStarted = false
+	RawStageNum = -1
+	ForcedEscapeStage = -1
+	ScriptedStageWave = 0
+	CooldownEndWarningTime = 8.5 // seconds before end of cooldown to play warning
+	CooldownEndWarningChance = 15 // percent chance to play warning
+	CooldownEndWarningFrequency = 0 // how many waves to wait before playing another warning
+	LastWaveCooldownWarningPlayed = -1 // the last wave that the cooldown warning played on
+}
+
+//---------------------------------------------------------
+// the DirectorOptions defaults for Holdout - though the maps will override many of these per wave and phase
+MutationOptions <-
+{
+	PreferredMobDirection = SPAWN_NO_PREFERENCE
+	SpawnSetRule = SPAWN_ANYWHERE
+	JournalString = ""
+	SpecialInfectedAssault = 0
+	AllowWitchesInCheckpoints = 1
+	AllowCrescendoEvents = 0
+	EnforceFinaleNavSpawnRules = 0
+	IgnoreNavThreatAreas = 1
+	ZombieDiscardRange = 10000
+
+	WanderingZombieDensityModifier = 0
+	BoomerLimit  = 0
+ 	ChargerLimit = 0
+ 	HunterLimit  = 0
+	JockeyLimit  = 0
+	SpitterLimit = 0
+	SmokerLimit  = 0
+	MaxSpecials  = 0
+	CommonLimit  = 20
+	TankLimit    = 0
+	MegaMobMaxSize = 100
+	MegaMobMinSize = 75
+	PanicWavePauseMax = 5
+	PanicWavePauseMin = 1
+	AddToSpawnTimer = 0
+	ShouldAllowMobsWithTank = true
+	ShouldAllowSpecialsWithTank = true
+	ZombieSpawnRange = 800
+	ZombieTankHealth = 6000 // SP default is 4000
+	BileMobSize = 20
+	EscapeSpawnTanks = true
+	ZombieDontClear = 1
+	MegaMobSize = 50       // i have no idea why this defaults to not between min and max
+
+	cm_ShouldEscortHumanPlayers = 1
+	cm_AggressiveSpecials = 1
+}
+
+//=========================================================
+// Utilities and helpers
+//=========================================================
+
+const PHASE_PANIC = 1
+const PHASE_CLEAR = 2
+const PHASE_DELAY = 0
+
+function StageNumToWaveBase( stagenum )
+{
+	return (stagenum + 2) / 3   // the +2 is because of our initial startup raw phases...
+}
+
+function WaveBaseToStageNum( wavebase, substage = PHASE_DELAY )
+{
+	return wavebase * 3 + substage
+}
+
+// Are players permitted to pick up this object by pressing their USE key?
+// return true for yes, false for no.
+function CanPickupObject( object )
+{
+	// mines
+	if ( object.GetName().find( "mine_1_body" ) )
+	{
+		return true
+	}
+	
+	// resource drops
+	if ( object.GetName().find( "prop_resource" ) )
+	{
+		return true
+	}
+
+	// check the map script for a PickupObject function for extra qualified items
+	// TODO: we should do this more generally!
+	local canPickup = false
+	if( "PickupObject" in g_MapScript )
+	{
+		canPickup = g_MapScript.PickupObject( object )
+	}
+	
+	return canPickup
+}
+
+// Called from other systems when they want the next combat wave to be the escape
+function StartEscapeWave()
+{
+	SessionState.ForcedEscapeStage =  ( ( SessionState.RawStageNum + 2 ) / 3) * 3 + 1
+	// printl( "Prepping Escape Wave for Stage " + SessionState.ForcedEscapeStage + " from " + SessionState.RawStageNum )
+}
+
+// show the final score and timing
+function HoldoutDisplayScores( )
+{
+	local final_time = Time() - SessionState.RealStartTime
+	local score_strings = Scoring_AddScoreAndBuildStrings( Scoring_MakeName(), final_time )
+	HUDPlace( HUD_TICKER, 0.32, 0.27, 0.36, 0.20 )
+	HUDPlace( HUD_FAR_RIGHT, 0.28, 0.50, 0.44, 0.06 )
+	HUDPlace( HUD_FAR_LEFT,  0.28, 0.58, 0.44, 0.06 )
+	HUDPlace( HUD_LEFT_BOT,  0.28, 0.66, 0.44, 0.06 )
+	HUDPlace( HUD_RIGHT_BOT, 0.28, 0.74, 0.44, 0.06 )
+	local ticker_str = score_strings.yourtime
+	if ("finish" in score_strings)
+		ticker_str = ticker_str + "\n" + score_strings.finish
+	ticker_str = ticker_str + "\nBest Times So Far"
+	Ticker_SetBlink( false )   // or true if you came in first?
+	Ticker_NewStr( ticker_str, 120 )
+	foreach (idx, val in score_strings.topscores)
+	{
+		local hudfield = "score"+(idx+1)
+		HoldoutHUD.Fields[hudfield].dataval = val
+		HoldoutHUD.Fields[hudfield].flags = HoldoutHUD.Fields[hudfield].flags & ~HUD_FLAG_NOTVISIBLE
+	}
+	Scoring_SaveTable( SessionState.MapName, SessionState.ModeName )
+}
+
+// if a chopper rescue, this is where we get called
+function RescuedByCopter( )
+{
+	// for now
+	HoldoutDisplayScores()
+}
+
+// @TODO - this is basically "dont shoot at mines" right? why is it here?
+function BotQuery( queryflag, entity, defaultvalue )
+{
+	switch( queryflag )
+	{
+		case BOT_QUERY_NOTARGET:
+		{
+			local classname = entity.GetClassname()
+			local targetname = entity.GetName()
+			if ( targetname && targetname.find( "mine_1_body" ) )
+			{
+				return false;
+			}
+			return true;
+		}
+	}
+	
+	return defaultvalue;
+}
+
+//----------------------------------------------------
+// Rather than checking every time to see if the map has defined each callback
+// instead we are going to check for each callback on startup
+//   if they arent there, we will insert a simple NOP lambda (if they are, we leave them)
+// For what these callbacks do, check top of file where they are described
+function OnGameplayStart()
+{
+	CheckOrSetMapCallback( "DoMapEventCheck", @() false )
+	CheckOrSetMapCallback( "DoMapSetup", @() null)
+	CheckOrSetMapCallback( "GetMapEscapeStage", @() null )
+	CheckOrSetMapCallback( "IsMapSpecificStage", @() false )
+	CheckOrSetMapCallback( "GetMapSpecificStage", @() null )
+	CheckOrSetMapCallback( "GetAttackStage", @() null )
+	CheckOrSetMapCallback( "GetMapClearoutStage", @() null )
+	CheckOrSetMapCallback( "GetMapDelayStage", @() null )
+
+	DoMapSetup()    // and then call the MapSpecific startup callback right away
+}
+
+//=========================================================
+//=========================================================
+function OnActivate()
+{
+	// @todo: put scoring back into holdout!
+	Scoring_LoadTable( SessionState.MapName, SessionState.ModeName )	
+
+	// this is so we can do some non-wave-based thinking
+	ScriptedMode_AddSlowPoll( HoldoutSlowPollUpdate )
+}
+
+//=========================================================
+//=========================================================
+function OnShutdown()
+{
+	ScriptedMode_RemoveSlowPoll( HoldoutSlowPollUpdate )
+}
+
+HoldoutHUD <- {}
+//=========================================================
+// since we have this mutation specific HUD but individual maps can use it differently
+// it is a bit more complicated than a normal HUD Setup
+// - use SessionState to tell the system which extra fields you want (Wave #, Timer, etc)
+// - check and warn if you try to set conflicting fields
+function SetupModeHUD()
+{
+	HoldoutHUD =
+	{
+		Fields = 
+		{
+			cooldown_time = { slot = HUD_LEFT_TOP, name = "cooldown", special = HUD_SPECIAL_COOLDOWN, flags = HUD_FLAG_COUNTDOWN_WARN | HUD_FLAG_BEEP },
+			supply        = { slot = HUD_RIGHT_TOP, name = "supply", staticstring = "Supplies: ", datafunc = @() g_MapScript.Resources.CurrentCount },
+
+			// this is kinda a lie! we are really going to move these w/HUDPlace for displaying final scores!
+			// we will move the Ticker down to be a "header" - then need 4 slots for top 4
+			score1   = { slot = HUD_FAR_RIGHT, name = "score1", dataval = "Score1", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+			score2   = { slot = HUD_FAR_LEFT,  name = "score2", dataval = "Score2", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+			score3   = { slot = HUD_LEFT_BOT,  name = "score3", dataval = "Score3", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+			score4   = { slot = HUD_RIGHT_BOT, name = "score4", dataval = "Score4", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
+		}
+	}
+	
+	if ( "HUDRescueTimer" in SessionState && SessionState.HUDRescueTimer )
+	{   
+		RescueTimer_Init( HoldoutHUD, HUD_MID_BOX, HUD_MID_BOT )
+ 		if (SessionState.HUDWaveInfo)
+ 			printl("Warning: Cannot have both Rescuetimer and Wave HUD elements at once");
+ 	}
+ 	else if ( "HUDWaveInfo" in SessionState && SessionState.HUDWaveInfo )
+ 	{
+		HoldoutHUD.Fields.wave <- {slot = HUD_MID_TOP, name = "wave", staticstring = "Wave: ", datafunc = @() SessionState.ScriptedStageWave }
+	}
+
+	if( "HUDTickerTimeout" in SessionState )
+	{
+		TickerTimeout = SessionState.HUDTickerTimeout
+	}
+	
+ 	if ( "HUDTickerText" in SessionState )
+ 	{
+ 		if ( SessionState.HUDTickerText.len() > 0 )
+ 		{
+ 			Ticker_AddToHud( HoldoutHUD, SessionState.HUDTickerText )
+ 		}
+ 	}
+
+	HUDSetLayout( HoldoutHUD );
+}
+
+//=========================================================
+// The scripted mode calls this function each time the generator turns on. 
+// The generator usually turns on because someone poured a can of fuel into it.
+//=========================================================
+function OnGeneratorStart()
+{
+	g_MapScript.RescueTimer_Start()
+}
+
+//=========================================================
+// Counterpart to OnGeneratorStart(), this is called when the generator sputters and stops
+//  usually because it has run out of fuel.
+//=========================================================
+function OnGeneratorStop()
+{
+	g_MapScript.RescueTimer_Stop()
+}
+
+//=========================================================
+// this is the base "system maintenance" for holdout mode timers and UI
+// It checks things like has rescue started, should we do a warning about cooldown about to end, etc
+//=========================================================
+function HoldoutSlowPollUpdate()
+{
+	RescueTimer_Tick()
+
+	if ( !SessionState.RescueStarted )
+	{
+		if ( "HUDRescueTimer" in SessionState && SessionState.HUDRescueTimer )
+		{
+			local seconds = g_MapScript.RescueTimer_Get()
+		
+			// start the rescue if the generator has run long enough
+			if( seconds <= 0 )
+			{
+				SessionState.RescueStarted = true
+				g_ModeScript.StartEscapeWave()
+			}
+		}
+	}
+
+	// CooldownEndWarningChance is the % chance that a random player will vocalize a warning
+	// when a cooldown is close to ending
+	if( "CooldownEndWarningChance" in SessionState )
+	{
+		local timeLeft = HUDReadTimer( HUD_SPECIAL_COOLDOWN )
+
+		if ( ( timeLeft < SessionState.CooldownEndWarningTime ) && ( timeLeft > 0 ) && ( SessionState.LastWaveCooldownWarningPlayed + SessionState.CooldownEndWarningFrequency < SessionState.ScriptedStageWave ) )
+		{
+			SessionState.LastWaveCooldownWarningPlayed = SessionState.ScriptedStageWave
+
+			// roll the dice...
+			local chance = RandomInt(0, 100 )
+
+			if( chance < SessionState.CooldownEndWarningChance )
+			{
+				// jackpot! collect the players into an array and select one at random to speak a line
+				local playerEnt = null
+				local playerArray = []
+
+				while ( playerEnt = Entities.FindByClassname( playerEnt, "player" ) )
+				{
+					if (playerEnt.IsSurvivor() )
+					{
+						playerArray.append( playerEnt)
+					}
+				}
+
+				local idx = RandomInt( 0, 3)
+
+				if( idx < playerArray.len() )
+				{
+					// fire entity IO at "!activator" and pass the player ent as the activator
+					EntFire( "!activator", "SpeakResponseConcept", "PlayerHurryUp", 0, playerArray[idx] )
+				}
+			}
+		}
+	}
+}
+
+function JournalFunc()
+{
+	DirectorOptions.JournalString = "{ resources = " + g_MapScript.Resources.CurrentCount
+	if (SessionState.HUDRescueTimer)
+		DirectorOptions.JournalString += ", rescue = " + RescueTimer_Get()
+	if ("JournalMapFunc" in this)
+		DirectorOptions.JournalString += JournalMapFunc()
+	DirectorOptions.JournalString += " }"
+}
+
+//=========================================================
+// A little digression of testing/demoing a "script based clearout"
+//  You can just do C++ based clearout (to let the mob population clearout) of course
+//  But from script, one can use a Poll function and GetInfectedStats to manage it yourself
+//  See sm_utilities for the actual code/systems if you want to do something like it
+
+// Whether to use the new Script based clearout or not - false here just means use the default c++ one 
+::g_ScriptClearout <- true
+
+// if you are going to use the new clearout - here is the table for determining it's behavior
+holdout_ClearoutTable <-
+{
+	commons = 2
+	specials = 0
+	tanks = 0
+	witches = 0
+	plateautime = 5
+	plateaucommons = 5
+	plateauspecials = 1
+	stopspecials = true
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// "Main Loop" of Holdout
+// 
+// GetNextStage gets called whenever the director finishes the last thing you told it to do
+//   or if you do a ForceNextStage yourself
+// In holdout, we use GetNextStage to manage the game, cycling through 3 types of Stage (as described at top)
+// At each stage, we make some of our callbacks (that we checked and set up in OnGameplayStart)
+// To determine what options we want for that stage - usually in the form of a "stagetable"
+//   which is basically just a set of DirectorOptions parameters and a few extra fields
+// And then we go and set all those fields in the director, set the stage type, and send the director off
+//
+///////////////////////////////////////////////////////////////////////////////
+
+function GetNextStage()
+{
+	local use_stage = null
+
+	local stageNum = ++SessionState.RawStageNum
+
+	SessionState.ScriptedStageWave = ( stageNum + 2 ) / 3
+
+	// first, special event management
+	DoMapEventCheck()
+	
+	// fire game events as we begin and end cooldown states - initial map stage 0 is considered a cooldown state
+	if( ( stageNum % 3 ) == PHASE_PANIC )
+		FireScriptEvent( "on_cooldown_end", null )
+	else if( ( ( stageNum % 3 ) == PHASE_DELAY ) || ( stageNum == 0 ) )
+		FireScriptEvent( "on_cooldown_begin", null )
+
+	// error check!
+	if (SessionState.ForcedEscapeStage != -1 && stageNum > SessionState.ForcedEscapeStage)
+		printl("Ummmmmm.... something has gone very wrong... we passed escape stage but are still picking next stages...");
+
+	if ( stageNum == 1) // 1st real attack stage
+	{
+		SessionState.RealStartTime <- Time() 
+		Director.ResetSpecialTimers()
+	}
+
+	//  now the generalized stage sequencing...
+	if ( stageNum == 0 )
+	{
+		DirectorOptions.ScriptedStageType = STAGE_SETUP
+		if ("HUDTickerText" in SessionState)
+			Ticker_NewStr(SessionState.HUDTickerText)  // since the time it got set as start in HUD load is ages ago
+	}
+	else if ( stageNum == SessionState.ForcedEscapeStage )
+	{
+		use_stage = GetMapEscapeStage()
+	}
+	else if ( IsMapSpecificStage() )
+		use_stage = GetMapSpecificStage()   // dont like this! potential out of sync/parallel variables
+	else if ( ( stageNum % 3 ) == PHASE_PANIC )
+	{
+		use_stage = GetAttackStage()
+		if (::g_ScriptClearout)
+			ClearoutNotifyPanicStart( holdout_ClearoutTable )
+	}
+	else if ( ( stageNum % 3 ) == PHASE_CLEAR )
+	{
+		if (::g_ScriptClearout)
+		{
+			ClearoutStart( holdout_ClearoutTable )
+			DirectorOptions.ScriptedStageType = STAGE_DELAY
+			DirectorOptions.ScriptedStageValue = -1	// Infinite
+		}
+		else
+			use_stage = GetMapClearoutStage()
+	}
+	else if ( ( stageNum % 3 ) == PHASE_DELAY )
+	{
+		use_stage = GetMapDelayStage()
+	}
+
+	// Put the special infected into assault mode - really want to do this sooner somehow? at maxspecials 0?
+	switch ( DirectorOptions.ScriptedStageType )
+	{
+		case STAGE_CLEAROUT:
+		case STAGE_DELAY:
+		case STAGE_ESCAPE:
+			DirectorOptions.SpecialInfectedAssault = 1
+			break;
+		default:
+			DirectorOptions.SpecialInfectedAssault = 0
+	}
+
+	if ( use_stage != null )
+	{
+		if ( "stageDefaults" in g_MapScript )
+			StageInfo_Execute( use_stage, stageDefaults )        // should use_stage just delegate?
+		else
+			StageInfo_Execute( use_stage )
+		
+		if ( "NextDelay" in use_stage )
+			SessionState.NextDelayTime <- use_stage.NextDelay    // just overwrite, so we dont need to if check
+		else
+			SessionState.NextDelayTime <- 30                     // better default from somewhere?
+	}
+
+	smDbgPrint( "Setting type " + DirectorOptions.ScriptedStageType + " and val " + DirectorOptions.ScriptedStageValue )
+}

--- a/root/scripts/vscripts/holdout.nut
+++ b/root/scripts/vscripts/holdout.nut
@@ -51,11 +51,11 @@ MutationOptions <-
 	PreferredMobDirection = SPAWN_NO_PREFERENCE
 	SpawnSetRule = SPAWN_ANYWHERE
 	JournalString = ""
-	SpecialInfectedAssault = 0
-	AllowWitchesInCheckpoints = 1
-	AllowCrescendoEvents = 0
-	EnforceFinaleNavSpawnRules = 0
-	IgnoreNavThreatAreas = 1
+	SpecialInfectedAssault = false
+	AllowWitchesInCheckpoints = true
+	AllowCrescendoEvents = false
+	EnforceFinaleNavSpawnRules = false
+	IgnoreNavThreatAreas = true
 	ZombieDiscardRange = 10000
 
 	WanderingZombieDensityModifier = 0
@@ -79,11 +79,11 @@ MutationOptions <-
 	ZombieTankHealth = 6000 // SP default is 4000
 	BileMobSize = 20
 	EscapeSpawnTanks = true
-	ZombieDontClear = 1
+	ZombieDontClear = true
 	MegaMobSize = 50       // i have no idea why this defaults to not between min and max
 
-	cm_ShouldEscortHumanPlayers = 1
-	cm_AggressiveSpecials = 1
+	cm_ShouldEscortHumanPlayers = true
+	cm_AggressiveSpecials = true
 }
 
 //=========================================================
@@ -472,10 +472,10 @@ function GetNextStage()
 		case STAGE_CLEAROUT:
 		case STAGE_DELAY:
 		case STAGE_ESCAPE:
-			DirectorOptions.SpecialInfectedAssault = 1
+			DirectorOptions.SpecialInfectedAssault = true
 			break;
 		default:
-			DirectorOptions.SpecialInfectedAssault = 0
+			DirectorOptions.SpecialInfectedAssault = false
 	}
 
 	if ( use_stage != null )

--- a/root/scripts/vscripts/holdout.nut
+++ b/root/scripts/vscripts/holdout.nut
@@ -60,8 +60,8 @@ MutationOptions <-
 
 	WanderingZombieDensityModifier = 0
 	BoomerLimit  = 0
- 	ChargerLimit = 0
- 	HunterLimit  = 0
+	ChargerLimit = 0
+	HunterLimit  = 0
 	JockeyLimit  = 0
 	SpitterLimit = 0
 	SmokerLimit  = 0
@@ -113,7 +113,7 @@ function CanPickupObject( object )
 	{
 		return true
 	}
-	
+
 	// resource drops
 	if ( object.GetName().find( "prop_resource" ) )
 	{
@@ -127,7 +127,7 @@ function CanPickupObject( object )
 	{
 		canPickup = g_MapScript.PickupObject( object )
 	}
-	
+
 	return canPickup
 }
 
@@ -186,7 +186,7 @@ function BotQuery( queryflag, entity, defaultvalue )
 			return true;
 		}
 	}
-	
+
 	return defaultvalue;
 }
 
@@ -214,7 +214,7 @@ function OnGameplayStart()
 function OnActivate()
 {
 	// @todo: put scoring back into holdout!
-	Scoring_LoadTable( SessionState.MapName, SessionState.ModeName )	
+	Scoring_LoadTable( SessionState.MapName, SessionState.ModeName )
 
 	// this is so we can do some non-wave-based thinking
 	ScriptedMode_AddSlowPoll( HoldoutSlowPollUpdate )
@@ -237,7 +237,7 @@ function SetupModeHUD()
 {
 	HoldoutHUD =
 	{
-		Fields = 
+		Fields =
 		{
 			cooldown_time = { slot = HUD_LEFT_TOP, name = "cooldown", special = HUD_SPECIAL_COOLDOWN, flags = HUD_FLAG_COUNTDOWN_WARN | HUD_FLAG_BEEP },
 			supply        = { slot = HUD_RIGHT_TOP, name = "supply", staticstring = "Supplies: ", datafunc = @() g_MapScript.Resources.CurrentCount },
@@ -250,15 +250,15 @@ function SetupModeHUD()
 			score4   = { slot = HUD_RIGHT_BOT, name = "score4", dataval = "Score4", flags = HUD_FLAG_NOTVISIBLE | HUD_FLAG_ALIGN_LEFT },
 		}
 	}
-	
+
 	if ( "HUDRescueTimer" in SessionState && SessionState.HUDRescueTimer )
-	{   
+	{
 		RescueTimer_Init( HoldoutHUD, HUD_MID_BOX, HUD_MID_BOT )
- 		if (SessionState.HUDWaveInfo)
- 			printl("Warning: Cannot have both Rescuetimer and Wave HUD elements at once");
- 	}
- 	else if ( "HUDWaveInfo" in SessionState && SessionState.HUDWaveInfo )
- 	{
+		if (SessionState.HUDWaveInfo)
+			printl("Warning: Cannot have both Rescuetimer and Wave HUD elements at once");
+	}
+	else if ( "HUDWaveInfo" in SessionState && SessionState.HUDWaveInfo )
+	{
 		HoldoutHUD.Fields.wave <- {slot = HUD_MID_TOP, name = "wave", staticstring = "Wave: ", datafunc = @() SessionState.ScriptedStageWave }
 	}
 
@@ -266,20 +266,20 @@ function SetupModeHUD()
 	{
 		TickerTimeout = SessionState.HUDTickerTimeout
 	}
-	
- 	if ( "HUDTickerText" in SessionState )
- 	{
- 		if ( SessionState.HUDTickerText.len() > 0 )
- 		{
- 			Ticker_AddToHud( HoldoutHUD, SessionState.HUDTickerText )
- 		}
- 	}
+
+	if ( "HUDTickerText" in SessionState )
+	{
+		if ( SessionState.HUDTickerText.len() > 0 )
+		{
+			Ticker_AddToHud( HoldoutHUD, SessionState.HUDTickerText )
+		}
+	}
 
 	HUDSetLayout( HoldoutHUD );
 }
 
 //=========================================================
-// The scripted mode calls this function each time the generator turns on. 
+// The scripted mode calls this function each time the generator turns on.
 // The generator usually turns on because someone poured a can of fuel into it.
 //=========================================================
 function OnGeneratorStart()
@@ -309,7 +309,7 @@ function HoldoutSlowPollUpdate()
 		if ( "HUDRescueTimer" in SessionState && SessionState.HUDRescueTimer )
 		{
 			local seconds = g_MapScript.RescueTimer_Get()
-		
+
 			// start the rescue if the generator has run long enough
 			if( seconds <= 0 )
 			{
@@ -374,7 +374,7 @@ function JournalFunc()
 //  But from script, one can use a Poll function and GetInfectedStats to manage it yourself
 //  See sm_utilities for the actual code/systems if you want to do something like it
 
-// Whether to use the new Script based clearout or not - false here just means use the default c++ one 
+// Whether to use the new Script based clearout or not - false here just means use the default c++ one
 ::g_ScriptClearout <- true
 
 // if you are going to use the new clearout - here is the table for determining it's behavior
@@ -393,7 +393,7 @@ holdout_ClearoutTable <-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // "Main Loop" of Holdout
-// 
+//
 // GetNextStage gets called whenever the director finishes the last thing you told it to do
 //   or if you do a ForceNextStage yourself
 // In holdout, we use GetNextStage to manage the game, cycling through 3 types of Stage (as described at top)
@@ -414,7 +414,7 @@ function GetNextStage()
 
 	// first, special event management
 	DoMapEventCheck()
-	
+
 	// fire game events as we begin and end cooldown states - initial map stage 0 is considered a cooldown state
 	if( ( stageNum % 3 ) == PHASE_PANIC )
 		FireScriptEvent( "on_cooldown_end", null )
@@ -427,7 +427,7 @@ function GetNextStage()
 
 	if ( stageNum == 1) // 1st real attack stage
 	{
-		SessionState.RealStartTime <- Time() 
+		SessionState.RealStartTime <- Time()
 		Director.ResetSpecialTimers()
 	}
 
@@ -484,7 +484,7 @@ function GetNextStage()
 			StageInfo_Execute( use_stage, stageDefaults )        // should use_stage just delegate?
 		else
 			StageInfo_Execute( use_stage )
-		
+
 		if ( "NextDelay" in use_stage )
 			SessionState.NextDelayTime <- use_stage.NextDelay    // just overwrite, so we dont need to if check
 		else

--- a/root/scripts/vscripts/l4d1.nut
+++ b/root/scripts/vscripts/l4d1.nut
@@ -87,7 +87,7 @@ function OnGameEvent_round_start_post_nav( params )
 	EntFire( "weapon_*", "AddOutput", "skin 0" );
 	EntFire( "weapon_*", "AddOutput", "weaponskin -1" );
 	EntFire( "trigger_upgrade_laser_sight", "Kill" );
-	
+
 	foreach( wep, val in DirectorOptions.weaponsToRemove )
 		EntFire( wep + "_spawn", "Kill" );
 	foreach( wep, val in DirectorOptions.weaponsToConvert )
@@ -106,11 +106,11 @@ function OnGameEvent_round_start_post_nav( params )
 			SpawnEntityFromTable(val, spawnTable);
 		}
 	}
-	
+
 	if ( Director.IsL4D1Campaign() )
 	{
 		DirectorOptions.WaterSlowsMovement <- false;
-		
+
 		if ( SessionState.ModeName == "l4d1coop" || SessionState.ModeName == "l4d1vs" )
 		{
 			if ( IsMissionFinalMap() )
@@ -175,14 +175,14 @@ function OnGameEvent_round_start_post_nav( params )
 function OnGameEvent_player_spawn( params )
 {
 	local player = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( ( !player ) || ( player.IsSurvivor() ) )
 		return;
-	
+
 	local modelName = player.GetModelName();
 	if ( ( modelName.find( "l4d1" ) != null ) || ( modelName == "models/infected/hulk_dlc3.mdl" ) )
 		return;
-	
+
 	switch( player.GetZombieType() )
 	{
 		case 1:
@@ -214,11 +214,11 @@ function OnGameEvent_player_death( params )
 {
 	if ( !("userid" in params) )
 		return;
-	
+
 	local victim = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( ( !victim ) || ( !victim.IsSurvivor() ) )
 		return;
-	
+
 	EntFire( "survivor_death_model", "BecomeRagdoll" );
 }

--- a/root/scripts/vscripts/mutation1.nut
+++ b/root/scripts/vscripts/mutation1.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 1\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -20,7 +19,7 @@ DirectorOptions <-
 	SpecialInitialSpawnDelayMin = 5
 	SpecialInitialSpawnDelayMax = 30
 	TankHitDamageModifierCoop = 0.5
-	
+
 	// convert items that aren't useful
 	weaponsToConvert =
 	{
@@ -42,7 +41,7 @@ DirectorOptions <-
 			return weaponsToConvert[classname];
 		}
 		return 0;
-	}	
+	}
 }
 
 function OnGameEvent_round_start_post_nav( params )
@@ -50,7 +49,7 @@ function OnGameEvent_round_start_post_nav( params )
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
 	{
 		local population = NetProps.GetPropString( spawner, "m_szPopulation" );
-		
+
 		if ( population == "boomer" || population == "hunter" || population == "smoker" || population == "jockey"
 			|| population == "charger" || population == "spitter" || population == "new_special" || population == "church"
 				|| population == "tank" || population == "witch" || population == "witch_bride" || population == "river_docks_trap" )
@@ -58,10 +57,10 @@ function OnGameEvent_round_start_post_nav( params )
 		else
 			spawner.Kill();
 	}
-	
+
 	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
-	
+
 	foreach( wep, val in DirectorOptions.weaponsToConvert )
 	{
 		for ( local wep_spawner; wep_spawner = Entities.FindByClassname( wep_spawner, wep + "_spawn" ); )

--- a/root/scripts/vscripts/mutation10.nut
+++ b/root/scripts/vscripts/mutation10.nut
@@ -6,6 +6,6 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_FirstManOut = 1
+	cm_FirstManOut = true
 }
 

--- a/root/scripts/vscripts/mutation10.nut
+++ b/root/scripts/vscripts/mutation10.nut
@@ -1,11 +1,9 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 10\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
 
 	cm_FirstManOut = true
 }
-

--- a/root/scripts/vscripts/mutation10.nut
+++ b/root/scripts/vscripts/mutation10.nut
@@ -1,0 +1,11 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 10\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	cm_FirstManOut = 1
+}
+

--- a/root/scripts/vscripts/mutation11.nut
+++ b/root/scripts/vscripts/mutation11.nut
@@ -1,0 +1,24 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 11\n");
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	weaponsToRemove =
+	{
+		weapon_first_aid_kit = 0
+		weapon_pain_pills = 0
+		weapon_adrenaline = 0
+		weapon_defibrillator = 0
+	}
+
+	function AllowWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToRemove )
+		{
+			return false;
+		}
+		return true;
+	}		
+}

--- a/root/scripts/vscripts/mutation11.nut
+++ b/root/scripts/vscripts/mutation11.nut
@@ -20,5 +20,5 @@ DirectorOptions <-
 			return false;
 		}
 		return true;
-	}		
+	}
 }

--- a/root/scripts/vscripts/mutation12.nut
+++ b/root/scripts/vscripts/mutation12.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 12\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -24,7 +23,7 @@ DirectorOptions <-
 			return false;
 		}
 		return true;
-	}		
+	}
 
 	DefaultItems =
 	[
@@ -39,5 +38,5 @@ DirectorOptions <-
 			return DefaultItems[idx];
 		}
 		return 0;
-	}	
+	}
 }

--- a/root/scripts/vscripts/mutation12.nut
+++ b/root/scripts/vscripts/mutation12.nut
@@ -6,7 +6,7 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_AllowPillConversion = 0
+	cm_AllowPillConversion = false
 
 	ZombieGhostDelayMin = 15
 	ZombieGhostDelayMax = 25

--- a/root/scripts/vscripts/mutation12.nut
+++ b/root/scripts/vscripts/mutation12.nut
@@ -1,0 +1,43 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 12\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	cm_AllowPillConversion = 0
+
+	ZombieGhostDelayMin = 15
+	ZombieGhostDelayMax = 25
+
+	weaponsToRemove =
+	{
+		weapon_first_aid_kit = 0
+		weapon_defibrillator = 0
+	}
+
+	function AllowWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToRemove )
+		{
+			return false;
+		}
+		return true;
+	}		
+
+	DefaultItems =
+	[
+		"weapon_first_aid_kit",
+		"weapon_pistol",
+	]
+
+	function GetDefaultItem( idx )
+	{
+		if ( idx < DefaultItems.len() )
+		{
+			return DefaultItems[idx];
+		}
+		return 0;
+	}	
+}

--- a/root/scripts/vscripts/mutation13.nut
+++ b/root/scripts/vscripts/mutation13.nut
@@ -1,8 +1,7 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 13\n");
 
-
-DirectorOptions <- 
+DirectorOptions <-
 {
 	ActiveChallenge = 1
 
@@ -10,4 +9,3 @@ DirectorOptions <-
 
 	ScavengeScoreBonusTime = 30
 }
-

--- a/root/scripts/vscripts/mutation13.nut
+++ b/root/scripts/vscripts/mutation13.nut
@@ -1,0 +1,13 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 13\n");
+
+
+DirectorOptions <- 
+{
+	ActiveChallenge = 1
+
+	cm_SingleScavengeCluster = 1
+
+	ScavengeScoreBonusTime = 30
+}
+

--- a/root/scripts/vscripts/mutation13.nut
+++ b/root/scripts/vscripts/mutation13.nut
@@ -6,7 +6,7 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_SingleScavengeCluster = 1
+	cm_SingleScavengeCluster = true
 
 	ScavengeScoreBonusTime = 30
 }

--- a/root/scripts/vscripts/mutation14.nut
+++ b/root/scripts/vscripts/mutation14.nut
@@ -1,0 +1,74 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 14\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	weaponsToRemove =
+	{
+		weapon_pistol = 0
+		weapon_pistol_magnum = 0
+		weapon_smg = 0
+		weapon_pumpshotgun = 0
+		weapon_autoshotgun = 0
+		weapon_rifle = 0
+		weapon_hunting_rifle = 0
+		weapon_smg_silenced = 0
+		weapon_shotgun_chrome = 0
+		weapon_rifle_desert = 0
+		weapon_sniper_military = 0
+		weapon_shotgun_spas = 0
+		weapon_grenade_launcher = 0
+		weapon_rifle_ak47 = 0
+		weapon_smg_mp5 = 0
+		weapon_rifle_sg552 = 0
+		weapon_sniper_awp = 0
+		weapon_sniper_scout = 0
+		weapon_rifle_m60 = 0
+		weapon_melee = 0
+		weapon_chainsaw = 0
+		ammo = 0
+	}
+
+	function AllowWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToRemove )
+		{
+			return false;
+		}
+		return true;
+	}
+
+	function ShouldAvoidItem( classname )
+	{
+		if ( ( classname != "weapon_rifle_m60" && classname != "weapon_pistol_magnum" ) && ( classname in weaponsToRemove ) )
+		{
+			return true;
+		}
+		return false;
+	}
+
+	DefaultItems =
+	[
+		"weapon_rifle_m60",
+		"weapon_pistol_magnum",
+	]
+
+	function GetDefaultItem( idx )
+	{
+		if ( idx < DefaultItems.len() )
+		{
+			return DefaultItems[idx];
+		}
+		return 0;
+	}
+}
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	EntFire( "weapon_spawn", "Kill" );
+	foreach( wep, val in DirectorOptions.weaponsToRemove )
+		EntFire( wep + "_spawn", "Kill" );
+}

--- a/root/scripts/vscripts/mutation14.nut
+++ b/root/scripts/vscripts/mutation14.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 14\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1

--- a/root/scripts/vscripts/mutation15.nut
+++ b/root/scripts/vscripts/mutation15.nut
@@ -6,7 +6,7 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_ProhibitBosses = 0
+	cm_ProhibitBosses = false
 	cm_CommonLimit = 25
 	cm_TankLimit = 1
 	ZombieTankHealth = 2667

--- a/root/scripts/vscripts/mutation15.nut
+++ b/root/scripts/vscripts/mutation15.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 15\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -50,7 +49,7 @@ function OnGameEvent_survival_round_start( params )
 					local outputTarget = Entities.FindByName( null, outputs.target );
 					if ( !outputTarget )
 						continue;
-					
+
 					if ( outputTarget.GetClassname() == "info_director" && outputs.input.find( "PanicEvent" ) != null )
 						return outputTarget;
 					else
@@ -74,11 +73,11 @@ function OnGameEvent_survival_round_start( params )
 			{
 				if ( !EntityOutputs.HasAction( ent, output ) )
 					continue;
-				
+
 				local target = CheckOutputs( ent, output );
 				if ( (!target) || (target.GetClassname() != "info_director") )
 					continue;
-				
+
 				return ent;
 			}
 		}

--- a/root/scripts/vscripts/mutation16.nut
+++ b/root/scripts/vscripts/mutation16.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 16\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1

--- a/root/scripts/vscripts/mutation17.nut
+++ b/root/scripts/vscripts/mutation17.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 17\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1

--- a/root/scripts/vscripts/mutation17.nut
+++ b/root/scripts/vscripts/mutation17.nut
@@ -6,7 +6,7 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_NoSurvivorBots = 1
+	cm_NoSurvivorBots = true
 
 	cm_CommonLimit = 10
 	cm_BaseCommonAttackDamage = 15

--- a/root/scripts/vscripts/mutation17.nut
+++ b/root/scripts/vscripts/mutation17.nut
@@ -1,0 +1,77 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 17\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	cm_NoSurvivorBots = 1
+
+	cm_CommonLimit = 10
+	cm_BaseCommonAttackDamage = 15
+	cm_WanderingZombieDensityModifier = 0.015
+
+	HunterLimit = 0
+	SmokerLimit = 0
+	ChargerLimit = 0
+	JockeyLimit = 0
+	SpitterLimit = 0
+
+	weaponsToRemove =
+	{
+		weapon_pistol = 0
+		weapon_smg = 0
+		weapon_pumpshotgun = 0
+		weapon_autoshotgun = 0
+		weapon_rifle = 0
+		weapon_hunting_rifle = 0
+		weapon_smg_silenced = 0
+		weapon_shotgun_chrome = 0
+		weapon_rifle_desert = 0
+		weapon_sniper_military = 0
+		weapon_shotgun_spas = 0
+		weapon_grenade_launcher = 0
+		weapon_rifle_ak47 = 0
+		weapon_smg_mp5 = 0
+		weapon_rifle_sg552 = 0
+		weapon_sniper_awp = 0
+		weapon_sniper_scout = 0
+		weapon_rifle_m60 = 0
+		weapon_melee = 0
+		weapon_chainsaw = 0
+		weapon_rifle_m60 = 0
+		ammo = 0
+		upgrade_item = 0
+	}
+
+	function AllowWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToRemove )
+		{
+			return false;
+		}
+		return true;
+	}
+
+	DefaultItems =
+	[
+		"weapon_pistol_magnum",
+	]
+
+	function GetDefaultItem( idx )
+	{
+		if ( idx < DefaultItems.len() )
+		{
+			return DefaultItems[idx];
+		}
+		return 0;
+	}
+}
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	EntFire( "weapon_spawn", "Kill" );
+	foreach( wep, val in DirectorOptions.weaponsToRemove )
+		EntFire( wep + "_spawn", "Kill" );
+}

--- a/root/scripts/vscripts/mutation18.nut
+++ b/root/scripts/vscripts/mutation18.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 18\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -18,7 +17,7 @@ DirectorOptions <-
 			return weaponsToConvert[classname];
 		}
 		return 0;
-	}	
+	}
 
 	// Challenge vars
 	cm_TempHealthOnly = true

--- a/root/scripts/vscripts/mutation18.nut
+++ b/root/scripts/vscripts/mutation18.nut
@@ -1,0 +1,41 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 18\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	weaponsToConvert =
+	{
+		weapon_first_aid_kit = "weapon_pain_pills_spawn"
+	}
+
+	function ConvertWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToConvert )
+		{
+			return weaponsToConvert[classname];
+		}
+		return 0;
+	}	
+
+	// Challenge vars
+	cm_TempHealthOnly = 1
+	cm_AllowPillConversion = 0
+	cm_ShouldHurry = 1
+
+	TempHealthDecayRate = 0.001
+	function RecalculateHealthDecay()
+	{
+		if ( Director.HasAnySurvivorLeftSafeArea() )
+		{
+			TempHealthDecayRate = 0.27 // pain_pills_decay_rate default
+		}
+	}
+}
+
+function Update()
+{
+	DirectorOptions.RecalculateHealthDecay();
+}

--- a/root/scripts/vscripts/mutation18.nut
+++ b/root/scripts/vscripts/mutation18.nut
@@ -21,9 +21,9 @@ DirectorOptions <-
 	}	
 
 	// Challenge vars
-	cm_TempHealthOnly = 1
-	cm_AllowPillConversion = 0
-	cm_ShouldHurry = 1
+	cm_TempHealthOnly = true
+	cm_AllowPillConversion = false
+	cm_ShouldHurry = true
 
 	TempHealthDecayRate = 0.001
 	function RecalculateHealthDecay()

--- a/root/scripts/vscripts/mutation19.nut
+++ b/root/scripts/vscripts/mutation19.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 19\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -21,7 +20,7 @@ DirectorOptions <-
 	function ConvertZombieClass( iClass )
 	{
 		return 8;
-	}	
+	}
 
 	weaponsToConvert =
 	{
@@ -56,7 +55,7 @@ function OnGameEvent_round_start_post_nav( params )
 				local outputTarget = Entities.FindByName( null, outputs.target );
 				if ( !outputTarget )
 					continue;
-				
+
 				if ( outputs.input == "Unlock" || outputs.input == "Enable" || outputs.input == "SetValueTest" || outputs.input == "MoveToFloor" )
 					return outputTarget;
 				else
@@ -77,12 +76,12 @@ function OnGameEvent_round_start_post_nav( params )
 	{
 		if ( NetProps.GetPropInt( trigger, "m_bAllowIncapTouch" ) == 0 || !EntityOutputs.HasAction( trigger, "OnEntireTeamStartTouch" ) )
 			continue;
-		
+
 		NetProps.SetPropInt( trigger, "m_bAllowIncapTouch", 0 );
 		local target = CheckOutputs( trigger, "OnEntireTeamStartTouch" );
 		if ( !target )
 			continue;
-		
+
 		if ( target.GetClassname() == "logic_relay" )
 		{
 			for ( local button; button = Entities.FindByClassname( button, "func_button" ); )
@@ -113,7 +112,7 @@ function OnGameEvent_round_start_post_nav( params )
 						break;
 					}
 				}
-				
+
 				if ( foundListener )
 				{
 					local nElements = EntityOutputs.GetNumElements( listener, "OnAllTrue" );
@@ -135,7 +134,7 @@ function OnGameEvent_round_start_post_nav( params )
 		local validOutputs = { func_button_timed = "OnTimeUp", func_button = "OnPressed", script_func_button = "OnPressed", prop_door_rotating = "OnOpen" };
 		if ( !target.GetClassname() in validOutputs )
 			continue;
-		
+
 		target.ValidateScriptScope();
 		local targetScope = target.GetScriptScope();
 		targetScope.OverrideTrigger <- trigger;

--- a/root/scripts/vscripts/mutation2.nut
+++ b/root/scripts/vscripts/mutation2.nut
@@ -1,0 +1,11 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 2\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	cm_HeadshotOnly = 1
+}
+

--- a/root/scripts/vscripts/mutation2.nut
+++ b/root/scripts/vscripts/mutation2.nut
@@ -6,6 +6,6 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_HeadshotOnly = 1
+	cm_HeadshotOnly = true
 }
 

--- a/root/scripts/vscripts/mutation2.nut
+++ b/root/scripts/vscripts/mutation2.nut
@@ -1,11 +1,9 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 2\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
 
 	cm_HeadshotOnly = true
 }
-

--- a/root/scripts/vscripts/mutation20.nut
+++ b/root/scripts/vscripts/mutation20.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 20\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -26,7 +25,7 @@ DirectorOptions <-
 	cm_TempHealthOnly = true
 	cm_AllowPillConversion = false
 	cm_HealingGnome = true
-	
+
 	TempHealthDecayRate = 0.001
 	function RecalculateHealthDecay()
 	{

--- a/root/scripts/vscripts/mutation20.nut
+++ b/root/scripts/vscripts/mutation20.nut
@@ -1,0 +1,43 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 20\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	weaponsToRemove =
+	{
+		weapon_first_aid_kit = 0
+		weapon_pain_pills = 0
+		weapon_adrenaline = 0
+	}
+
+	function AllowWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToRemove )
+		{
+			return false;
+		}
+		return true;
+	}
+
+	// Challenge vars
+	cm_TempHealthOnly = 1
+	cm_AllowPillConversion = 0
+	cm_HealingGnome = 1
+	
+	TempHealthDecayRate = 0.001
+	function RecalculateHealthDecay()
+	{
+		if ( Director.HasAnySurvivorLeftSafeArea() )
+		{
+			TempHealthDecayRate = 0.27 // pain_pills_decay_rate default
+		}
+	}
+}
+
+function Update()
+{
+	DirectorOptions.RecalculateHealthDecay();
+}

--- a/root/scripts/vscripts/mutation20.nut
+++ b/root/scripts/vscripts/mutation20.nut
@@ -23,9 +23,9 @@ DirectorOptions <-
 	}
 
 	// Challenge vars
-	cm_TempHealthOnly = 1
-	cm_AllowPillConversion = 0
-	cm_HealingGnome = 1
+	cm_TempHealthOnly = true
+	cm_AllowPillConversion = false
+	cm_HealingGnome = true
 	
 	TempHealthDecayRate = 0.001
 	function RecalculateHealthDecay()

--- a/root/scripts/vscripts/mutation3.nut
+++ b/root/scripts/vscripts/mutation3.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 3\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -18,7 +17,7 @@ DirectorOptions <-
 			return weaponsToConvert[classname];
 		}
 		return 0;
-	}	
+	}
 
 	// Challenge vars
 	cm_TempHealthOnly = true

--- a/root/scripts/vscripts/mutation3.nut
+++ b/root/scripts/vscripts/mutation3.nut
@@ -21,9 +21,9 @@ DirectorOptions <-
 	}	
 
 	// Challenge vars
-	cm_TempHealthOnly = 1
-	cm_AllowPillConversion = 0
-	cm_ShouldHurry = 1
+	cm_TempHealthOnly = true
+	cm_AllowPillConversion = false
+	cm_ShouldHurry = true
 	cm_MaxSpecials = 4
 	cm_SpecialRespawnInterval = 45
 	cm_WanderingZombieDensityModifier = 0.003

--- a/root/scripts/vscripts/mutation3.nut
+++ b/root/scripts/vscripts/mutation3.nut
@@ -1,0 +1,58 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 3\n");
+
+
+DirectorOptions <-
+{
+	ActiveChallenge = 1
+
+	weaponsToConvert =
+	{
+		weapon_first_aid_kit = "weapon_pain_pills_spawn"
+	}
+
+	function ConvertWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToConvert )
+		{
+			return weaponsToConvert[classname];
+		}
+		return 0;
+	}	
+
+	// Challenge vars
+	cm_TempHealthOnly = 1
+	cm_AllowPillConversion = 0
+	cm_ShouldHurry = 1
+	cm_MaxSpecials = 4
+	cm_SpecialRespawnInterval = 45
+	cm_WanderingZombieDensityModifier = 0.003
+
+	// Global vars
+	MobSpawnMinTime = 5
+	MobSpawnMaxTime = 10
+	MobMinSize = 10
+	MobMaxSize = 15
+	MobMaxPending = 30
+	SustainPeakMinTime = 10
+	SustainPeakMaxTime = 15
+	IntensityRelaxThreshold = 0.95
+	RelaxMinInterval = 3
+	RelaxMaxInterval = 5
+	RelaxMaxFlowTravel = 50
+	PreferredMobDirection = SPAWN_BEHIND_SURVIVORS
+
+	TempHealthDecayRate = 0.001
+	function RecalculateHealthDecay()
+	{
+		if ( Director.HasAnySurvivorLeftSafeArea() )
+		{
+			TempHealthDecayRate = 0.27 // pain_pills_decay_rate default
+		}
+	}
+}
+
+function Update()
+{
+	DirectorOptions.RecalculateHealthDecay();
+}

--- a/root/scripts/vscripts/mutation4.nut
+++ b/root/scripts/vscripts/mutation4.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 4\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1

--- a/root/scripts/vscripts/mutation5.nut
+++ b/root/scripts/vscripts/mutation5.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 5\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1
@@ -13,7 +12,7 @@ DirectorOptions <-
 
 	SpecialInitialSpawnDelayMin = 5
 	SpecialInitialSpawnDelayMax = 30
-	
+
 	// convert items that aren't useful
 	weaponsToConvert =
 	{
@@ -29,7 +28,7 @@ DirectorOptions <-
 			return weaponsToConvert[classname];
 		}
 		return 0;
-	}	
+	}
 
 	weaponsToRemove =
 	{
@@ -98,7 +97,7 @@ function OnGameEvent_round_start_post_nav( params )
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
 	{
 		local population = NetProps.GetPropString( spawner, "m_szPopulation" );
-		
+
 		if ( population == "boomer" || population == "hunter" || population == "smoker" || population == "jockey"
 			|| population == "charger" || population == "spitter" || population == "new_special" || population == "church"
 				|| population == "tank" || population == "witch" || population == "witch_bride" || population == "river_docks_trap" )
@@ -106,10 +105,10 @@ function OnGameEvent_round_start_post_nav( params )
 		else
 			spawner.Kill();
 	}
-	
+
 	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
-	
+
 	EntFire( "weapon_spawn", "Kill" );
 	foreach( wep, val in DirectorOptions.weaponsToRemove )
 		EntFire( wep + "_spawn", "Kill" );

--- a/root/scripts/vscripts/mutation7.nut
+++ b/root/scripts/vscripts/mutation7.nut
@@ -6,8 +6,8 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_InfiniteFuel = 1
-	cm_ShouldHurry = 1
+	cm_InfiniteFuel = true
+	cm_ShouldHurry = true
 
 	weaponsToRemove =
 	{

--- a/root/scripts/vscripts/mutation7.nut
+++ b/root/scripts/vscripts/mutation7.nut
@@ -1,7 +1,6 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 7\n");
 
-
 DirectorOptions <-
 {
 	ActiveChallenge = 1

--- a/root/scripts/vscripts/mutation8.nut
+++ b/root/scripts/vscripts/mutation8.nut
@@ -1,0 +1,25 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 8\n");
+
+
+DirectorOptions <- 
+{
+	ActiveChallenge = 1
+
+	cm_AllowSurvivorRescue = 0
+
+	weaponsToRemove =
+	{
+		ammo = 0
+	}
+
+	function AllowWeaponSpawn( classname )
+	{
+		if ( classname in weaponsToRemove )
+		{
+			return false;
+		}
+		return true;
+	}	
+}
+

--- a/root/scripts/vscripts/mutation8.nut
+++ b/root/scripts/vscripts/mutation8.nut
@@ -6,7 +6,7 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_AllowSurvivorRescue = 0
+	cm_AllowSurvivorRescue = false
 
 	weaponsToRemove =
 	{

--- a/root/scripts/vscripts/mutation8.nut
+++ b/root/scripts/vscripts/mutation8.nut
@@ -1,8 +1,7 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 8\n");
 
-
-DirectorOptions <- 
+DirectorOptions <-
 {
 	ActiveChallenge = 1
 
@@ -20,6 +19,5 @@ DirectorOptions <-
 			return false;
 		}
 		return true;
-	}	
+	}
 }
-

--- a/root/scripts/vscripts/mutation9.nut
+++ b/root/scripts/vscripts/mutation9.nut
@@ -1,0 +1,12 @@
+//-----------------------------------------------------
+Msg("Activating Mutation 9\n");
+
+
+DirectorOptions <- 
+{
+	ActiveChallenge = 1
+
+	cm_VIPTarget = 1
+	cm_ShouldHurry = 1
+}
+

--- a/root/scripts/vscripts/mutation9.nut
+++ b/root/scripts/vscripts/mutation9.nut
@@ -1,12 +1,10 @@
 //-----------------------------------------------------
 Msg("Activating Mutation 9\n");
 
-
-DirectorOptions <- 
+DirectorOptions <-
 {
 	ActiveChallenge = 1
 
 	cm_VIPTarget = true
 	cm_ShouldHurry = true
 }
-

--- a/root/scripts/vscripts/mutation9.nut
+++ b/root/scripts/vscripts/mutation9.nut
@@ -6,7 +6,7 @@ DirectorOptions <-
 {
 	ActiveChallenge = 1
 
-	cm_VIPTarget = 1
-	cm_ShouldHurry = 1
+	cm_VIPTarget = true
+	cm_ShouldHurry = true
 }
 

--- a/root/scripts/vscripts/tankrun.nut
+++ b/root/scripts/vscripts/tankrun.nut
@@ -18,7 +18,7 @@ MutationOptions <-
 	cm_MaxSpecials = 0
 	cm_ProhibitBosses = true
 	cm_AggressiveSpecials = true
-	
+
 	BoomerLimit = 0
 	SmokerLimit = 0
 	HunterLimit = 0
@@ -27,7 +27,7 @@ MutationOptions <-
 	JockeyLimit = 0
 	cm_WitchLimit = 0
 	cm_TankLimit = 8
-	
+
 	MobMinSize = 0
 	MobMaxSize = 0
 	NoMobSpawns = true
@@ -94,7 +94,7 @@ if ( IsMissionFinalMap() )
 	local triggerFinale = Entities.FindByClassname( null, "trigger_finale" );
 	if ( triggerFinale )
 		MutationState.FinaleType = NetProps.GetPropInt( triggerFinale, "m_type" );
-	
+
 	TankRunHUD <- {};
 	function SetupModeHUD()
 	{
@@ -107,7 +107,7 @@ if ( IsMissionFinalMap() )
 		}
 		HUDSetLayout( TankRunHUD );
 	}
-	
+
 	if ( MutationState.FinaleType != 4 )
 	{
 		function GetNextStage()
@@ -134,16 +134,16 @@ if ( IsMissionFinalMap() )
 			SessionState.TanksDisabled = false;
 			SessionState.SpawnTankThink = true;
 		}
-		
+
 		if ( SessionState.FinaleType == 4 )
 			return;
-		
+
 		SessionState.DoubleTanks = true;
 		SessionState.SpawnInterval = 40;
 		SessionState.FinaleStarted = true;
 		SessionState.FinaleStartTime = Time();
 		SessionState.TriggerRescueThink = true;
-		
+
 		HUDManageTimers( 0, TIMER_COUNTDOWN, SessionState.RescueDelay );
 		TankRunHUD.Fields.rescue_time.flags = TankRunHUD.Fields.rescue_time.flags & ~HUD_FLAG_NOTVISIBLE;
 	}
@@ -168,7 +168,7 @@ function AllowTakeDamage( damageTable )
 {
 	if ( !damageTable.Attacker || !damageTable.Victim || !damageTable.Inflictor )
 		return true;
-	
+
 	if ( damageTable.Victim.IsPlayer() && damageTable.Attacker.IsPlayer() )
 	{
 		if ( damageTable.Attacker.IsSurvivor() && damageTable.Victim.GetZombieType() == 8 )
@@ -177,7 +177,7 @@ function AllowTakeDamage( damageTable )
 				damageTable.DamageDone = 500;
 		}
 	}
-	
+
 	return true;
 }
 
@@ -195,7 +195,7 @@ function SpawnTankThink()
 {
 	if ( SessionOptions.cm_TankLimit == 0 )
 		return;
-	
+
 	if ( (SessionState.TanksAlive < 8) && ((Time() - SessionState.LastSpawnTime) >= SessionState.SpawnInterval || SessionState.LastSpawnTime == 0) )
 	{
 		if ( ZSpawn( { type = 8 } ) )
@@ -213,7 +213,7 @@ function LeftSafeAreaThink()
 	{
 		if ( NetProps.GetPropInt( player, "m_iTeamNum" ) != 2 )
 			continue;
-		
+
 		if ( ResponseCriteria.GetValue( player, "instartarea" ) == "0" )
 		{
 			SessionState.LeftSafeAreaThink = false;
@@ -253,15 +253,15 @@ if ( Director.IsFirstMapInScenario() )
 				break;
 			}
 		}
-		
+
 		if ( !startPos )
 			return;
-		
+
 		for ( local weapon; weapon = Entities.FindByClassnameWithin( weapon, "weapon_*", startPos, 1200 ); )
 		{
 			if ( weapon.GetOwnerEntity() )
 				continue;
-			
+
 			local weaponName = weapon.GetClassname();
 			local primaryNames = [ "smg", "rifle", "shotgun", "sniper", "grenade" ];
 			if ( weaponName == "weapon_spawn" )
@@ -271,14 +271,14 @@ if ( Director.IsFirstMapInScenario() )
 					continue;
 				primaryNames.append( "any" );
 			}
-			
+
 			foreach( name in primaryNames )
 			{
 				if ( weaponName.find( name ) != null )
 					return;
 			}
 		}
-		
+
 		local itemNames = [ "weapon_pistol_spawn", "weapon_pistol_magnum_spawn", "weapon_spawn", "weapon_melee_spawn" ];
 		foreach( name in itemNames )
 		{
@@ -291,12 +291,12 @@ if ( Director.IsFirstMapInScenario() )
 				break;
 			}
 		}
-		
+
 		local w = [ "any_smg", "tier1_shotgun" ];
 		for ( local i = 0; i < 2; i++ )
 			SpawnEntityFromTable( "weapon_spawn", { spawn_without_director = 1, weapon_selection = w[i], count = 5, spawnflags = 3, origin = (startArea.FindRandomSpot() + Vector(0,0,50)), angles = Vector(RandomInt(0,90),RandomInt(0,90),90) } );
 	}
-	
+
 	function OnGameplayStart()
 	{
 		SessionState.CheckPrimaryWeaponThink = true;
@@ -308,7 +308,7 @@ function OnGameEvent_round_start_post_nav( params )
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
 	{
 		local population = NetProps.GetPropString( spawner, "m_szPopulation" );
-		
+
 		if ( population == "tank" || population == "river_docks_trap" )
 			continue;
 		else
@@ -316,7 +316,7 @@ function OnGameEvent_round_start_post_nav( params )
 	}
 	for ( local ammo; ammo = Entities.FindByModel( ammo, "models/props/terror/ammo_stack.mdl" ); )
 		ammo.Kill();
-	
+
 	if ( SessionState.MapName == "c5m5_bridge" || SessionState.MapName == "c6m3_port" || SessionState.MapName == "c13m4_cutthroatcreek" )
 	{
 		SessionOptions.cm_TankLimit = 0;
@@ -327,7 +327,7 @@ function OnGameEvent_round_start_post_nav( params )
 		EntFire( "tank_touch_test", "Kill" );
 		EntFire( "tankdoorout_button", "Unlock" );
 	}
-	
+
 	CheckDifficultyForTankHealth( GetDifficulty() );
 }
 
@@ -340,14 +340,14 @@ function OnGameEvent_player_left_safe_area( params )
 {
 	if ( SessionState.TanksDisabled )
 		return;
-	
+
 	local player = GetPlayerFromUserID( params["userid"] );
 	if ( !player )
 	{
 		SessionState.SpawnTankThink = true;
 		return;
 	}
-	
+
 	if ( ResponseCriteria.GetValue( player, "instartarea" ) == "1" )
 		SessionState.LeftSafeAreaThink = true;
 	else
@@ -359,7 +359,7 @@ function OnGameEvent_player_incapacitated( params )
 	local player = GetPlayerFromUserID( params["userid"] );
 	if ( (!player) || (!player.IsSurvivor()) )
 		return;
-	
+
 	player.ReviveFromIncap();
 }
 
@@ -368,7 +368,7 @@ function ReviveFromLedgeHang( userid )
 	local player = GetPlayerFromUserID( userid );
 	if ( (!player) || (!player.IsSurvivor()) )
 		return;
-	
+
 	player.ReviveFromIncap();
 }
 
@@ -377,7 +377,7 @@ function OnGameEvent_player_ledge_grab( params )
 	local player = GetPlayerFromUserID( params["userid"] );
 	if ( (!player) || (!player.IsSurvivor()) )
 		return;
-	
+
 	EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.ReviveFromLedgeHang(" + params["userid"] + ")", 0.1 );
 }
 
@@ -390,15 +390,15 @@ function OnGameEvent_player_now_it( params )
 {
 	local attacker = GetPlayerFromUserID( params["attacker"] );
 	local victim = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( !attacker || !victim )
 		return;
-	
+
 	if ( attacker.IsSurvivor() && victim.GetZombieType() == 8 )
 	{
 		if ( victim in SessionState.TankBiled )
 			return;
-		
+
 		victim.OverrideFriction( Convars.GetFloat( "vomitjar_duration_infected_bot" ), 2.0 );
 		SessionState.TankBiled.rawset( victim, attacker );
 		if ( SessionState.TankBiled.len() == 1 )
@@ -409,10 +409,10 @@ function OnGameEvent_player_now_it( params )
 function OnGameEvent_player_no_longer_it( params )
 {
 	local victim = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( !victim )
 		return;
-	
+
 	if ( victim.GetZombieType() == 8 )
 	{
 		if ( victim in SessionState.TankBiled )
@@ -438,23 +438,23 @@ function OnGameEvent_tank_spawn( params )
 	local tank = GetPlayerFromUserID( params["userid"] );
 	if ( !tank )
 		return;
-	
+
 	SessionState.TanksAlive++;
 	tank.SetMaxHealth( SessionState.TankHealth );
 	tank.SetHealth( SessionState.TankHealth );
 	local modelName = tank.GetModelName();
-	
+
 	if ( !SessionState.ModelCheck )
 	{
 		SessionState.ModelCheck = true;
-		
+
 		if ( SessionState.TankModelsBase.find( modelName ) == null )
 		{
 			SessionState.TankModelsBase.append( modelName );
 			SessionState.TankModels.append( modelName );
 		}
 	}
-	
+
 	local tankModels = SessionState.TankModels;
 	if ( tankModels.len() == 0 )
 		SessionState.TankModels.extend( SessionState.TankModelsBase );
@@ -464,27 +464,27 @@ function OnGameEvent_tank_spawn( params )
 		tankModels.remove( foundModel );
 		return;
 	}
-	
+
 	local randomElement = RandomInt( 0, tankModels.len() - 1 );
 	local randomModel = tankModels[ randomElement ];
 	tankModels.remove( randomElement );
-	
+
 	tank.SetModel( randomModel );
 }
 
 function OnGameEvent_tank_killed( params )
 {
 	SessionState.TanksAlive--;
-	
+
 	local tank = GetPlayerFromUserID( params["userid"] );
-	
+
 	if ( tank in SessionState.TankBiled )
 	{
 		SessionState.TankBiled.rawdelete( tank );
 		if ( SessionState.TankBiled.len() == 0 )
 			SessionState.BileHurtTankThink = false;
 	}
-	
+
 	if ( SessionState.FinaleStarted )
 	{
 		SessionState.RescueDelay -= 10;


### PR DESCRIPTION
This PR simply enforces that boolean DirectorOptions keys are set with boolean literals. It also improves **consistency** by following the recent trend in the community mutations to switch to booleans. I separated the commits for the EMS mutations in case they should be treated differently. I also skipped RocketDude and Confogl as these are versioned mutations with their own repo.