### PR TITLE
Update community5.nut

### DIFF
--- a/root/scripts/vscripts/community5.nut
+++ b/root/scripts/vscripts/community5.nut
@@ -10,6 +10,7 @@ DirectorOptions <-
 	cm_AllowPillConversion = false
 	cm_AllowSurvivorRescue = false
 	SurvivorMaxIncapacitatedCount = 0
+	TempHealthDecayRate = 0.0
 
 	function AllowFallenSurvivorItem( classname )
 	{
@@ -48,22 +49,22 @@ DirectorOptions <-
 		}
 		return 0;
 	}
+}
 
-	TempHealthDecayRate = 0.001
-	function RecalculateHealthDecay()
-	{
-		if ( Director.HasAnySurvivorLeftSafeArea() )
-		{
-			TempHealthDecayRate = 0.27 // pain_pills_decay_rate default
-		}
-	}
+function OnGameEvent_round_start( params )
+{
+	Convars.SetValue( "pain_pills_decay_rate", 0.0 );
+}
+
+function OnGameEvent_player_left_safe_area( params )
+{
+	DirectorOptions.TempHealthDecayRate = 0.27;
 }
 
 function OnGameEvent_player_hurt_concise( params )
 {
 	local player = GetPlayerFromUserID( params["userid"] );
-
-	if ( (!player) || (!player.IsSurvivor()) )
+	if ( (!player) || (!player.IsSurvivor()) || (player.IsHangingFromLedge()) )
 		return;
 
 	if ( NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 0 && player.GetHealth() < (player.GetMaxHealth() / 4) )
@@ -71,6 +72,18 @@ function OnGameEvent_player_hurt_concise( params )
 		player.SetReviveCount( 0 );
 		NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
 	}
+}
+
+function OnGameEvent_defibrillator_used( params )
+{
+	local player = GetPlayerFromUserID( params["subject"] );
+	if ( (!player) || (!player.IsSurvivor()) )
+		return;
+
+	player.SetHealth( 24 );
+	player.SetHealthBuffer( 36 );
+	player.SetReviveCount( 0 );
+	NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
 }
 
 function CheckHealthAfterLedgeHang( userid )
@@ -89,7 +102,6 @@ function CheckHealthAfterLedgeHang( userid )
 function OnGameEvent_revive_success( params )
 {
 	local player = GetPlayerFromUserID( params["subject"] );
-
 	if ( (!params["ledge_hang"]) || (!player) || (!player.IsSurvivor()) )
 		return;
 
@@ -100,14 +112,61 @@ function OnGameEvent_revive_success( params )
 function OnGameEvent_bot_player_replace( params )
 {
 	local player = GetPlayerFromUserID( params["player"] );
-
 	if ( (!player) || (NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 1) )
 		return;
 
 	StopSoundOn( "Player.Heartbeat", player );
 }
 
-function Update()
+if ( !Director.IsSessionStartMap() )
 {
-	DirectorOptions.RecalculateHealthDecay();
+	function PlayerSpawnDeadAfterTransition( userid )
+	{
+		local player = GetPlayerFromUserID( userid );
+		if ( !player )
+			return;
+
+		player.SetHealth( 24 );
+		player.SetHealthBuffer( 26 );
+		player.SetReviveCount( 0 );
+		NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
+	}
+
+	function PlayerSpawnAliveAfterTransition( userid )
+	{
+		local player = GetPlayerFromUserID( userid );
+		if ( !player )
+			return;
+
+		local maxHealth = player.GetMaxHealth();
+		local oldHealth = player.GetHealth();
+		local maxHeal = maxHealth / 2;
+		local healAmount = 0;
+
+		if ( oldHealth < maxHeal )
+			healAmount = floor( ((maxHeal - oldHealth) * 0.8) + 0.5 );
+
+		if ( healAmount > 0 )
+		{
+			player.SetHealth( oldHealth + healAmount );
+			local bufferHealth = player.GetHealthBuffer() - healAmount;
+			if ( bufferHealth < 0.0 )
+				bufferHealth = 0.0;
+			player.SetHealthBuffer( bufferHealth );
+		}
+		NetProps.SetPropInt( player, "m_bIsOnThirdStrike", 0 );
+		NetProps.SetPropInt( player, "m_isGoingToDie", 0 );
+	}
+
+	function OnGameEvent_player_transitioned( params )
+	{
+		local player = GetPlayerFromUserID( params["userid"] );
+		if ( (!player) || (!player.IsSurvivor()) )
+			return;
+
+		if ( NetProps.GetPropInt( player, "m_lifeState" ) == 2 )
+			EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.PlayerSpawnDeadAfterTransition(" + params["userid"] + ")", 0.1 );
+		else
+			EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.PlayerSpawnAliveAfterTransition(" + params["userid"] + ")", 0.1 );
+	}
 }


### PR DESCRIPTION
- Fixed temporary health decay in the safe room, loading players will no longer decay temp health.
- Fixed B&W state transition when hanging.
- Fixed heartbeat sound on chapter transition.
- Defibrillator now heals 24 permanent + 36 temporary HP (still B&W).
- Safe room respawn now heals 24 permanent + 26 temporary HP (still B&W).
- Safe room transitions now heal 80% of the missing HP to half health of living survivors, i.e. 1 -> 40 (never B&W).