### PR TITLE
Talker Patch

### DIFF
--- a/root/scripts/talker/coach.txt
+++ b/root/scripts/talker/coach.txt
@@ -3342,6 +3342,14 @@ Rule EllisStoryInterruptGenericC5M5Coach
 	Response EllisStoryInterruptGenericCoach
 }
 
+Rule EllisStoryInterruptGenericC13M4Coach
+{
+	criteria ConceptEllisInterrupt IsCoach IsMapc13m4_cutthroatcreek _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericCoach
+}
+
 Response EllisStoryReac01Coach
 {
 	scene "scenes/Coach/DLC1_C6M2_SafeRoomConvo15.vcd"  then Producer EllisStoryReac01 foo:0 -.5 //Girl! What are you doing?
@@ -5060,8 +5068,8 @@ Rule SurvivorSpottedCedaCoach
 
 Rule SurvivorSpottedCedaC1M1Coach
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel SawFirstHazmat IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:20,SawHazmat:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsCoach IsTalk IsTalkCoach IsWorldTalkCoach IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaCoach
 }
@@ -5375,6 +5383,8 @@ Rule SurvivorSpottedJockeyAlsoC1M2Coach
 
 Response SurvivorSpottedMudmenCoach
 {
+	norepeat
+	scene "scenes/Coach/SeeMudmen01.vcd"  //Mudmen!
 	scene "scenes/Coach/SeeMudmen02.vcd"  //Shoot the mudmen!
 }
 Rule SurvivorSpottedMudmenCoach
@@ -5387,7 +5397,7 @@ Rule SurvivorSpottedMudmenCoach
 
 Response SurvivorSpottedMudmenC3M2Coach
 {
-	scene "scenes/Coach/SeeMudmen01.vcd"  //Mudmen!
+	scene "scenes/Coach/GooedBySpitterC103.vcd"  //You have got to be kidding me.
 }
 Rule SurvivorSpottedMudmenC3M2Coach
 {

--- a/root/scripts/talker/gambler.txt
+++ b/root/scripts/talker/gambler.txt
@@ -3166,8 +3166,10 @@ Rule EllisStoryInterruptGambler
 Response EllisStoryInterruptGenericGambler
 {
 	scene "scenes/Gambler/EllisInterrupt12.vcd"  //Ohhh, not again...
+	scene "scenes/Gambler/EllisInterrupt07.vcd" odds 5 //Hey Ellis, why don't you tell us about the time you SHUT UP?
 	scene "scenes/Gambler/EllisInterrupt08.vcd"  then mechanic EllisStoryReac01 foo:0 0.01 //Ellis. Is now the best time?
 	scene "scenes/Gambler/EllisInterrupt19.vcd"  //You know what I like best about your stories? The sound they make when they stop.
+	scene "scenes/Gambler/EllisInterrupt20.vcd" odds 5 //You know what I like best about your stories, Ellis? NOTHING!
 }
 Rule EllisStoryInterruptGenericGambler
 {
@@ -3272,6 +3274,13 @@ Rule EllisStoryInterruptC5M5Gambler
 	Response EllisStoryInterruptC5M5Gambler
 }
 
+Rule EllisStoryInterruptC13M4Gambler
+{
+	criteria ConceptEllisInterrupt IsGambler ismapc13m4_cutthroatcreek _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptC5M5Gambler
+}
 
 //--------------------------------------------------------------------------------------------------------------
 // C5M5
@@ -5176,12 +5185,13 @@ Rule SurvivorSpottedCedaGambler
 
 Response SurvivorSpottedCedaC1M1Gambler
 {
+	norepeat
 	scene "scenes/Gambler/SeeHazmat02.vcd"  //Guess those suits don't stop bites.
 }
 Rule SurvivorSpottedCedaC1M1Gambler
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsGambler IsTalk IsTalkGambler IsWorldTalkGambler IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel SawFirstHazmat IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:20,SawHazmat:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsGambler IsTalk IsTalkGambler IsWorldTalkGambler IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaC1M1Gambler
 }
@@ -5409,6 +5419,7 @@ Rule SurvivorSpottedInfectedGambler
 Response SurvivorSpottedJimmyGambler
 {
 	scene "scenes/Gambler/ReactionNegative07.vcd"  //Holy Shit!
+	scene "scenes/Gambler/WorldC2M1B03.vcd"  //God DAMN you, Jimmy Gibbs, Jr.
 }
 Rule SurvivorSpottedJimmyGambler
 {

--- a/root/scripts/talker/mechanic.txt
+++ b/root/scripts/talker/mechanic.txt
@@ -4922,6 +4922,19 @@ Rule C4M4EllisStoryMechanic
 	Response C4M4EllisStoryMechanic
 }
 
+Response C4M5EllisStoryMechanic
+{
+	scene "scenes/Mechanic/DLC1_COMMUNITYE23.vcd"  then any EllisInterrupt foo:0 -4.20	//"I ever tell you about the time my buddy Keith told me that he was picked up by some little green men and they..."
+}
+Rule C4M5EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking isc4m5 IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C4M5EllisStoryMechanic
+}
+
 Response C5M2EllisStoryMechanic
 {
 	scene "scenes/Mechanic/EllisStoriesF01.vcd"  then any EllisInterrupt foo:0 -8.54 //Do you know what suck the heads means?  Because I came down here with Keith once and he didn't know and... It ain't nothin' bad.  It's about eatin'.
@@ -5056,6 +5069,44 @@ Rule EllisStoryReac01GoatMechanic
 	Response EllisStoryReac01GoatMechanic
 }
 
+Response C13M2EllisStoryMechanic
+{
+	scene "scenes/Mechanic/EllisStoriesL01.vcd"  then any EllisInterrupt foo:0 -15.53 //I ever tell you guys about the time my buddy Keith got rolled by a gator in a swamp? He didn't antagonize it or nothing, we were just trying to grab two so we could piss them off and get 'em to fight.
+}
+Rule C13M2EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking IsMapc13m2_southpinestream IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C13M2EllisStoryMechanic
+}
+
+Response C13M3EllisStoryMechanic
+{
+	scene "scenes/Mechanic/DLC1_KeithStories01.vcd"  then any EllisInterrupt foo:0 -16.0 //This one time, my buddy, Keith, got a tattoo. "I'M A MORON!" Right across his forehead. Of course, he made $200 off of that. So you ask yourself. Who's the REAL moron, huh?
+}
+Rule C13M3EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking IsMapc13m3_memorialbridge IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C13M3EllisStoryMechanic
+}
+
+Response C13M4EllisStoryMechanic
+{
+	scene "scenes/Mechanic/EllisStoriesS01.vcd"  then any EllisInterrupt foo:0 -18.21 //One the time the army bombed my buddy Keith. He went camping and didn't bother reading the signs, and I guess they were testing bombs that day-all sorts of stuff too, not just regular bombs.
+}
+Rule C13M4EllisStoryMechanic
+{
+	criteria ConceptTalkIdle IsMechanic IsInStartArea IsNotSaidLeavingSafeArea IsNotSpeaking IsMapc13m4_cutthroatcreek IsACoopMode ChanceToFire10Percent IsNotSrcGrp_ELLISSTORY _auto_IsStoryWait _auto_NotStoryGate
+	ApplyContext "_auto_TellingStory:1:0,SrcGrp_ELLISSTORY:1:0"
+	applycontexttoworld
+	forceweight 1
+	Response C13M4EllisStoryMechanic
+}
 
 //--------------------------------------------------------------------------------------------------------------
 // Finale Speech
@@ -5809,12 +5860,13 @@ Rule SurvivorSpottedCedaMechanic
 
 Response SurvivorSpottedCedaC1M1Mechanic
 {
+	norepeat
 	scene "scenes/Mechanic/SeeHazmat02.vcd"  //Watch out for the ones in the hazmat suits.
 }
 Rule SurvivorSpottedCedaC1M1Mechanic
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel SawFirstHazmat IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:20,SawHazmat:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsMechanic IsTalk IsTalkMechanic IsWorldTalkMechanic IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaC1M1Mechanic
 }

--- a/root/scripts/talker/producer.txt
+++ b/root/scripts/talker/producer.txt
@@ -2682,6 +2682,14 @@ Rule EllisStoryReac01Producer
 	Response EllisStoryReac01Producer
 }
 
+Rule EllisStoryInterruptC13M4Producer
+{
+	criteria ConceptEllisInterrupt IsProducer IsMapc13m4_cutthroatcreek _auto_IsTellingStory _auto_NotDidInterrupt
+	ApplyContext "_auto_DidInterrupt:1:0,_auto_TellingStory:0:0"
+	applycontexttoworld
+	Response EllisStoryInterruptGenericProducer
+}
+
 //--------------------------------------------------------------------------------------------------------------
 // C5M5
 //--------------------------------------------------------------------------------------------------------------
@@ -4848,12 +4856,13 @@ Rule SurvivorSpottedCedaProducer
 
 Response SurvivorSpottedCedaC1M1Producer
 {
+	norepeat
 	scene "scenes/Producer/SeeHazmat01.vcd"  //Great. Infected in hazmat suits.
 }
 Rule SurvivorSpottedCedaC1M1Producer
 {
-	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel SawFirstHazmat IsNotSpeakingWeight0
-	ApplyContext "SaidCedaWarn:1:20,SawHazmat:++1"
+	criteria ConceptPlayerWarnSpecial IsSpecialTypeCeda IsNotCoughing IsProducer IsTalk IsTalkProducer IsWorldTalkProducer IsNotIncapacitated IsNotSaidCedaWarn ismap_c1m1_hotel IsNotSpeakingWeight0
+	ApplyContext "SaidCedaWarn:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedCedaC1M1Producer
 }
@@ -5080,6 +5089,7 @@ Response SurvivorSpottedJimmyProducer
 {
 	scene "scenes/Producer/WorldC1M3B17.vcd"  //Take that, Jimmy Gibbs!
 	scene "scenes/Producer/WorldC1M3B18.vcd"  //Eat lead, Jimmy Gibbs.
+	scene "scenes/Producer/WorldC1M4B12.vcd"  //Dibs on Gibbs!
 }
 Rule SurvivorSpottedJimmyProducer
 {


### PR DESCRIPTION
Coach:
1. Adds a generic Ellis story interrupt on c13m4, because Nick has a unique interrupt.
2. "SpottedCedac1m1" no longer uses "SawFirstHazmat".
3. Restores a "SawFirstMudmen" line to his generic mudmen callouts.
4. Adds a new "SawFirstMudmen" line to replace the previous one.

Gambler:
1. Adds two previously unused Ellis story interrupts to "EllisStoryInterruptGeneric".
2. Adds a unique Ellis story interrupt to c13m4.
3. "SpottedCedac1m1" no longer uses "SawFirstHazmat".
**4. Restores a Jimmy Gibbs callout that is currently in the Live version of the game, but was eroneously deleted in the current Github verion. (!!!)**

Mechanic:
1. Adds Ellis Stories to c4m5, c13m2, c13m3, and c13m4.
2. "SpottedCedac1m1" no longer uses "SawFirstHazmat".

Producer:
**1. Fixes a major error on the current Github version that shows errors instead of ellipses. (!!!)**
2. Adds a generic Ellis story interrupt on c13m4, because Nick has a unique interrupt.
3. "SpottedCedac1m1" no longer uses "SawFirstHazmat".
**4. Restores a Jimmy Gibbs callout that is currently in the Live version of the game, but was eroneously deleted in the current Github verion. (!!!)**