### PR TITLE
Corrected gnome normal map

### DIFF
--- a/root/materials/models/weapons/melee/gnome.vmt
+++ b/root/materials/models/weapons/melee/gnome.vmt
@@ -1,0 +1,35 @@
+"VertexLitGeneric"
+{
+    "$baseTexture" "models\Weapons\melee/Gnome"
+	"$phong" "1"
+	"$phongexponent" "150"
+	"$phongboost" "1"	
+	"$phongfresnelranges"	"[.7 15 20]"
+	"$bumpmap" "models/weapons/melee/gnome_normal" 
+
+
+//   "$envmap" "env_cubemap"
+
+//////////////////////////////////////////////////////
+
+	"$detail" "models/infected/hunter/hunter_01_detail.vtf"
+
+	"$detailscale" "1.75"
+	"$detailblendfactor" .001	// effectively turns the detail texture off in hlmv.  need something non-zero to enable it in-game though.
+	"$detailblendmode" 0
+	"$detailAmount" "0"
+
+	"Proxies"
+	{
+		"BloodyHands"
+		{
+			"resultVar" "$detailAmount" 
+		}
+
+		"Equals"
+		{
+			"srcVar1" "$detailAmount" 
+			"resultVar" "$detailblendfactor"
+		}
+	}
+}


### PR DESCRIPTION
Corrects a possible placeholder normal map being used instead of the correct one.
Retail uses:
>"$bumpmap" "models/props_fortifications/orangecone001_normal"

Changed to:
>"$bumpmap" "models/weapons/melee/gnome_normal"