### PR TITLE
Hard Rain Finale Music Fix

### DIFF
--- a/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
+++ b/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
@@ -70,6 +70,9 @@ DirectorOptions <-
 	CommonLimit = 20
 	SpecialRespawnInterval = 80
 
+	MusicDynamicMobSpawnSize = 8
+	MusicDynamicMobStopSize = 2
+	MusicDynamicMobScanStopSize = 1
 
 }
 

--- a/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
+++ b/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
@@ -70,9 +70,7 @@ DirectorOptions <-
 	CommonLimit = 20
 	SpecialRespawnInterval = 80
 
-	MusicDynamicMobSpawnSize = 8
-	MusicDynamicMobStopSize = 2
-	MusicDynamicMobScanStopSize = 1
+	MusicDynamicMobSpawnSize = 20
 
 }
 

--- a/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
+++ b/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
@@ -1,0 +1,83 @@
+
+//-----------------------------------------------------
+local PANIC = 0
+local TANK = 1
+local DELAY = 2
+//-----------------------------------------------------
+
+// default finale patten - for reference only
+
+/*
+CustomFinale1 <- PANIC
+CustomFinaleValue1 <- 2
+
+CustomFinale2 <- DELAY
+CustomFinaleValue2 <- 10
+
+CustomFinale3 <- TANK
+CustomFinaleValue3 <- 1
+
+CustomFinale4 <- DELAY
+CustomFinaleValue4 <- 10
+
+CustomFinale5 <- PANIC
+CustomFinaleValue5 <- 2
+
+CustomFinale6 <- DELAY
+CustomFinaleValue6 <- 10
+
+CustomFinale7 <- TANK
+CustomFinaleValue7 <- 1
+
+CustomFinale8 <- DELAY
+CustomFinaleValue8 <- 2
+*/
+
+DirectorOptions <-
+{
+	//-----------------------------------------------------
+
+	// 3 waves of mobs in between tanks
+
+	 A_CustomFinale_StageCount = 8
+	 
+	 A_CustomFinale1 = PANIC
+	 A_CustomFinaleValue1 = 1
+	 
+	 A_CustomFinale2 = DELAY
+	 A_CustomFinaleValue2 = 10
+	 
+	 A_CustomFinale3 = TANK
+	 A_CustomFinaleValue3 = 1
+	 
+	 A_CustomFinale4 = DELAY
+	 A_CustomFinaleValue4 = 10
+	 
+	 A_CustomFinale5 = PANIC
+	 A_CustomFinaleValue5 = 1
+	 
+	 A_CustomFinale6 = DELAY
+	 A_CustomFinaleValue6 = 10
+	 
+	 A_CustomFinale7 = TANK
+	 A_CustomFinaleValue7 = 1
+	 
+	 A_CustomFinale8 = DELAY
+	 A_CustomFinaleValue8 = 15
+	 
+	 
+	HordeEscapeCommonLimit = 15
+	CommonLimit = 20
+	SpecialRespawnInterval = 80
+
+
+}
+
+
+if ( "DirectorOptions" in LocalScript && "ProhibitBosses" in LocalScript.DirectorOptions )
+{
+	delete LocalScript.DirectorOptions.ProhibitBosses
+}
+
+/*
+*/

--- a/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
+++ b/root/scripts/vscripts/c4m5_milltown_escape_finale.nut
@@ -69,7 +69,6 @@ DirectorOptions <-
 	HordeEscapeCommonLimit = 15
 	CommonLimit = 20
 	SpecialRespawnInterval = 80
-
 	MusicDynamicMobSpawnSize = 20
 
 }


### PR DESCRIPTION
# What exactly is changed and why?

All L4D1 and L4D2 finales are supposed to play music during the horde waves; however, due to an oversight, Hard Rain was prevented from playing the horde music and so the finale is strangely quiet. 

Fixes the "MusicDynamicMob" music not working on this finale. The default settings for "MusicDynamicMob" makes the music not start until 25 commons have spawned, but this finale reduces the common limit to 20, so it was impossible for the music to function.

The specific changes I made are consistent with other L4D1 and L4D2 finales that change these cvars.

# Is there anything specific that needs review?

No

# Does this address any open issues?
Fixes #305