### PR TITLE
Fix gauntlet finale outros

### DIFF
--- a/root/scripts/vscripts/community/functions.nut
+++ b/root/scripts/vscripts/community/functions.nut
@@ -1446,6 +1446,44 @@ function patch_spawninfront( strOrigin, strMins, strMaxs )
 }
 
 /*****************************************************************************
+**  PATCH_OUTRO
+**
+**  The official gauntlet finales have an issue where the outro sequence is
+**  broken if the rescue trigger is activated before the trigger_finale is
+**  spawned by its template (which happens after the first button press). This
+**  can occur in many ways: skipping the finale by grenade boosting, GL
+**  boosting, low gravity, noclip, warping, ent_fire... The consequence is
+**  that inputs, such as FinaleEscapeForceSurvivorPositions and
+**  FinaleEscapeFinished, fail because the outro relay assumes that
+**  trigger_finale exists (survivors fall through or glitch in the rescue
+**  vehicle, and the stats are not counted, respectively). This patch
+**  increases robustness in these finales.
+*****************************************************************************/
+
+function patch_outro( strOutroRelay, strFinaleTemplate )
+{
+	local relay;
+
+	if ( relay = Entities.FindByName( null, strOutroRelay ) )
+	{
+		EntityOutputs.AddOutput( relay, "OnTrigger", "!self", "RunScriptCode", "CheckFinale(\"" + strFinaleTemplate + "\")", 0.0, 1 );
+
+		if ( developer() > 0 )
+		{
+			printl( "Enforced that " + strFinaleTemplate + " spawned for the " + strOutroRelay + " outro\n" );
+		}
+	}
+}
+
+function CheckFinale( strFinaleTemplate )
+{
+	if ( !Entities.FindByClassname( null, "trigger_finale" ) )
+	{
+		EntFire( strFinaleTemplate, "ForceSpawn" );
+	}
+}
+
+/*****************************************************************************
 **  MAKE_ATOMIZER
 **
 **  Tanks are able to hit prop_physics with rocks which causes them to never

--- a/root/scripts/vscripts/community/maps/c13m4_cutthroatcreek.nut
+++ b/root/scripts/vscripts/community/maps/c13m4_cutthroatcreek.nut
@@ -8,29 +8,36 @@ PrecacheModel( "models/props_foliage/tree_trunk_fallen.mdl" );
 
 function DoRoundFixes()
 {
-	make_clip(	"_permstuck_treetunnel",	"Everyone",	1,	"-16 -17 -10",		"17 16 45",		"-492.1 -186.3 -385" );
-	make_clip(	"_dispcrouch_toomany",		"Everyone",	1,	"0 0 -80",		"128 128 9001",		"-3028 -6154 413" );
-	make_clip( "_eventskip_rooftop", "Survivors", 1, "-317 -401 0", "323 367 689", "-3891 -8135 723" );
-	make_clip( "_eventskip_fence1", "Survivors", 1, "-59 -16 0", "60 16 910", "-4268 -8520 504" );
-	make_clip( "_eventskip_fence2", "Survivors", 1, "-151 -20 0", "849 20 914", "-3409 -7764 500" );
-	make_clip( "_cliprework_startbooster", "Survivors", 1, "-86 -520 -863", "203 361 226", "-4930 -5987 1188" );
-	make_clip( "_cliprework_endbooster", "Survivors", 1, "-72 -103 -175", "63 91 1415", "-1175 1405 57" );
-	make_clip( "_dispcrouch_onewaydrop", "Everyone", 1, "-402 -64 -64", "465 18 422", "-3893 -5852 -128" );
-	make_clip( "_cliprework_dispcrouch00", "SI Players and AI", 1, "-64 -149 -164", "18 87 146", "-4030 -5257 132", "0 -5 0" );
-	make_clip( "_cliprework_dispcrouch01", "Survivors", 1, "-64 -269 -64", "18 277 1446", "-4030 -5357 -32", "0 -5 0" );
-	make_clip( "_cliprework_dispcrouch02", "Survivors", 1, "-64 -269 -64", "18 1097 1446", "-4020 -4815 -32", "0 3 0" );
-	make_clip( "_cliprework_dispcrouch03", "Survivors", 1, "-64 -102 -64", "18 478 1446", "-4180 -1920 -32", "0 -21 0" );
-	make_clip( "_cliprework_dispcrouch04", "Survivors", 1, "-64 -22 -64", "18 408 1446", "-3971 -1527 -32", "0 -94 0" );
-	make_clip( "_cliprework_dispcrouch05", "Survivors", 1, "-64 -22 -64", "18 439 1446", "-3551 -1552 -32", "0 -64 0" );
-	make_clip( "_cliprework_dispcrouch06", "Survivors", 1, "-64 -157 -64", "18 369 1446", "-3126 -1398 -32", "0 -104 0" );
-	make_clip( "_cliprework_dispcrouch07", "Survivors", 1, "-64 -157 -64", "18 451 1446", "-2619 -1469 -31", "0 -84 0" );
-	make_clip( "_cliprework_dispcrouch08", "SI Players", 1, "-138 -16 -128", "48 16 216", "-2314 -2346 130", "0 -15 0" );
-	make_clip( "_cliprework_dispcrouch09", "SI Players", 1, "-138 -16 -128", "198 16 216", "-2172 -2422 130", "0 -17 0" );
-	make_clip( "_cliprework_dispcrouch10", "SI Players", 1, "-138 -16 -128", "488 16 108", "-1839 -2492 130", "0 13 0" );
-	make_clip( "_cliprework_dispcrouch11", "SI Players", 1, "-138 -16 -177", "488 16 0", "-1238 -2465 130", "0 -1 0" );
-	make_clip( "_cliprework_dispcrouch12", "SI Players", 1, "-8 -171 -42", "8 188 102", "415 -921 77", "0 -5 0" );
-	make_clip( "_dispcrouch_waterfall", "Everyone", 1, "-64 -188 -64", "18 263 272", "-2184 -1700 -288", "0 -10 0" );
-	make_clip( "_permstuck_umheymatt", "Everyone", 1, "-16 -128 0", "16 128 142", "13 5280 -117" );
+	make_clip( "_permstuck_treetunnel",		"Everyone",		1, "-16 -17 -10",	"17 16 45",		"-492.1 -186.3 -385" );
+	make_clip( "_dispcrouch_toomany",		"Everyone",		1, "0 0 -80",		"128 128 9001",	"-3028 -6154 413" );
+	make_clip( "_eventskip_rooftop",		"Survivors",	1, "-317 -401 0",	"323 367 689",	"-3891 -8135 723" );
+	make_clip( "_eventskip_fence1",			"Survivors",	1, "-59 -16 0",		"60 16 910",	"-4268 -8520 504" );
+	make_clip( "_eventskip_fence2",			"Survivors",	1, "-151 -20 0",	"849 20 914",	"-3409 -7764 500" );
+	make_clip( "_cliprework_startbooster",	"Survivors",	1, "-86 -520 -863",	"203 361 226",	"-4930 -5987 1188" );
+	make_clip( "_cliprework_endbooster",	"Survivors",	1, "-72 -103 -175",	"63 91 1415",	"-1175 1405 57" );
+	make_clip( "_dispcrouch_onewaydrop",	"Everyone",		1, "-402 -64 -64",	"465 18 422",	"-3893 -5852 -128" );
+	make_clip( "_cliprework_dispcrouch00",	"SI Players and AI", 1, "-64 -149 -164", "18 87 146", "-4030 -5257 132", "0 -5 0" );
+	make_clip( "_cliprework_dispcrouch01",	"Survivors",	1, "-64 -269 -64",	"18 277 1446",	"-4030 -5357 -32",	"0 -5 0" );
+	make_clip( "_cliprework_dispcrouch02",	"Survivors",	1, "-64 -269 -64",	"18 1097 1446",	"-4020 -4815 -32",	"0 3 0" );
+	make_clip( "_cliprework_dispcrouch03",	"Survivors",	1, "-64 -102 -64",	"18 478 1446",	"-4180 -1920 -32",	"0 -21 0" );
+	make_clip( "_cliprework_dispcrouch04",	"Survivors",	1, "-64 -22 -64",	"18 408 1446",	"-3971 -1527 -32",	"0 -94 0" );
+	make_clip( "_cliprework_dispcrouch05",	"Survivors",	1, "-64 -22 -64",	"18 439 1446",	"-3551 -1552 -32",	"0 -64 0" );
+	make_clip( "_cliprework_dispcrouch06",	"Survivors",	1, "-64 -157 -64",	"18 369 1446",	"-3126 -1398 -32",	"0 -104 0" );
+	make_clip( "_cliprework_dispcrouch07",	"Survivors",	1, "-64 -157 -64",	"18 451 1446",	"-2619 -1469 -31",	"0 -84 0" );
+	make_clip( "_cliprework_dispcrouch08",	"SI Players",	1, "-138 -16 -128",	"48 16 216",	"-2314 -2346 130",	"0 -15 0" );
+	make_clip( "_cliprework_dispcrouch09",	"SI Players",	1, "-138 -16 -128",	"198 16 216",	"-2172 -2422 130",	"0 -17 0" );
+	make_clip( "_cliprework_dispcrouch10",	"SI Players",	1, "-138 -16 -128",	"488 16 108",	"-1839 -2492 130",	"0 13 0" );
+	make_clip( "_cliprework_dispcrouch11",	"SI Players",	1, "-138 -16 -177",	"488 16 0",		"-1238 -2465 130",	"0 -1 0" );
+	make_clip( "_cliprework_dispcrouch12",	"SI Players",	1, "-8 -171 -42",	"8 188 102",	"415 -921 77",		"0 -5 0" );
+	make_clip( "_dispcrouch_waterfall",		"Everyone",		1, "-64 -188 -64",	"18 263 272",	"-2184 -1700 -288",	"0 -10 0" );
+	make_clip( "_permstuck_umheymatt",		"Everyone",		1, "-16 -128 0",	"16 128 142",	"13 5280 -117" );
+	patch_outro( "relay_escape_ends", "finale_template" );
+
+	local ent;
+	ent = Entities.FindByName( null, "trigger_boat" );
+	EntityOutputs.RemoveOutput( ent, "OnEntireTeamStartTouch", "finale", "FinaleEscapeForceSurvivorPositions", "" );
+	ent = Entities.FindByName( null, "relay_escape_ends" );
+	EntityOutputs.AddOutput( ent, "OnTrigger", "finale", "FinaleEscapeForceSurvivorPositions", "", 0.2, 1 );
 
 	if ( g_BaseMode == "versus" )
 	{
@@ -44,11 +51,11 @@ function DoRoundFixes()
 	if ( HasPlayerControlledZombies() )
 	{
 		kill_entity( Entities.FindByClassnameNearest( "prop_physics", Vector( -521.5, -1260.25, -399.53125 ), 8 ) );
-		make_clip(	"_ladder_startstreamL_clip",	"SI Players",	1,	"0 -30 -8",	"120 60 8",	"-4028 -5137 345", "0 90 31" );
-		make_clip(	"_ladder_littlecliff_qola",	"SI Players",	1,	"-60 0 -8",	"40 50 8",	"-3685 -1397 312", "0 20 45" );
-		make_clip(	"_ladder_littlecliff_qolb",	"SI Players",	1,	"-60 -24 -8",	"44 20 12",	"-3706 -1352 366", "0 20 45" );
-		make_brush( "_losfix_gen1",		"-1 -24 -8",	"1 24 8",	"-821 5675.32 -110" );
-		make_brush( "_losfix_gen2",		"-24 -1 -8",	"24 1 8",	"-838 4598 -110" );
+		make_clip( "_ladder_startstreamL_clip",	"SI Players",	1, "0 -30 -8",		"120 60 8",	"-4028 -5137 345",	"0 90 31" );
+		make_clip( "_ladder_littlecliff_qola",	"SI Players",	1, "-60 0 -8",		"40 50 8",	"-3685 -1397 312",	"0 20 45" );
+		make_clip( "_ladder_littlecliff_qolb",	"SI Players",	1, "-60 -24 -8",	"44 20 12",	"-3706 -1352 366",	"0 20 45" );
+		make_brush( "_losfix_gen1",	"-1 -24 -8",	"1 24 8",	"-821 5675.32 -110" );
+		make_brush( "_losfix_gen2",	"-24 -1 -8",	"24 1 8",	"-838 4598 -110" );
 		make_ladder( "_ladder_cornerlowroofl_cloned_endbackarea", "-1 5304 -43.124", "-1245 660 107" );
 		make_ladder( "_ladder_cornerlowroofr_cloned_endbackarea", "-1 5304 -43.124", "-1245 692 107" );
 		make_ladder( "_ladder_enddumpsterL_cloned_endstackback", "-38 5888 -55.124", "-6748 5750 -30", "0 -90 0", "0 -1 0" );
@@ -65,12 +72,12 @@ function DoRoundFixes()
 		make_prop( "dynamic", "_solidify_startcluster1", "models/props_foliage/urban_trees_cluster01.mdl", "-3130 -6492 366.443", "0 0 0", "shadow_no" );
 		make_prop( "dynamic", "_solidify_startcluster2", "models/props_foliage/urban_trees_cluster01.mdl", "-3168 -5984 317.023", "0 0 0", "shadow_no" );
 		make_prop( "physics", "_hittable_replacement", "models/props_foliage/tree_trunk_fallen.mdl", "-714 -863 -385", "0 100 0", "shadow_yes", "solid_yes", "255 255 255", -1, 0, 1.5 );
-		patch_ladder( "-1 5304 -43.124", "50 0 0" );
 		patch_ladder( "-202.0005 -1483.2271 -224", "0 0 10" );
-		patch_ladder( "145 4845.5 202", "-15 0 0" );
-		patch_ladder( "159 4845.5 159", "-15 0 0" );
-		patch_ladder( "178 4845.5 109.5", "-17 0 0" );
-		patch_ladder( "195 4845.5 -18.624", "-17 0 0" );
+		patch_ladder( "-1 5304 -43.124",	"50 0 0" );
+		patch_ladder( "145 4845.5 202",		"-15 0 0" );
+		patch_ladder( "159 4845.5 159",		"-15 0 0" );
+		patch_ladder( "178 4845.5 109.5",	"-17 0 0" );
+		patch_ladder( "195 4845.5 -18.624",	"-17 0 0" );
 	}
 }
 

--- a/root/scripts/vscripts/community/maps/c5m5_bridge.nut
+++ b/root/scripts/vscripts/community/maps/c5m5_bridge.nut
@@ -7,44 +7,45 @@ PrecacheModel( "models/props_rooftop/acvent03.mdl" );
 
 function DoRoundFixes()
 {
-	make_clip(	"_antiboost_finaleskip",	"Survivors",	1,	"-216 -295 -96",	"216 330 9001",		"-12017 6306 779" );
-	make_clip(	"_permstuck_semiwheels",	"Everyone",	1,	"-45 -30 -75",		"45 30 75",		"5929 6072 475" );
-	make_clip(	"_endfence_curvejump",		"Survivors",	1,	"-112 -80 -180",	"112 80 2400",		"9552 6640 556" );
-	make_clip(	"_endfence_commonhop",		"Survivors",	1,	"-24 -240 -55",		"24 240 17",		"9480 6320 705" );
-	make_clip(	"_bunnyhop_fence",		"Survivors",	1,	"-68 -71 -163",		"68 80 163",		"-11827 6526 611" );
-	make_clip(	"_solidify_bridgepier01",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-11786 6325 200" );
-	make_clip(	"_solidify_bridgepier03",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-9226 6325 200" );
-	make_clip(	"_solidify_bridgepier02",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-11274 6325 200" );
-	make_clip(	"_solidify_bridgepier04",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-8586 6325 200" );
-	make_clip(	"_solidify_bridgepier05",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-7434 6325 200" );
-	make_clip(	"_solidify_bridgepier06",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-6154 6325 200" );
-	make_clip(	"_solidify_bridgepier07",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-4618 6325 200" );
-	make_clip(	"_solidify_bridgepier08",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-3082 6325 200" );
-	make_clip(	"_solidify_bridgepier09",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-1546 6325 200" );
-	make_clip(	"_solidify_bridgepier10",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"-10 6325 200" );
-	make_clip(	"_solidify_bridgepier11",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"1526 6325 200" );
-	make_clip(	"_solidify_bridgepier12",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"3062 6325 200" );
-	make_clip(	"_solidify_bridgepier13",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"3990 6326 200" );
-	make_clip(	"_solidify_bridgepier14",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"4599 6326 200" );
-	make_clip(	"_solidify_bridgepier15",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"6662 6326 200" );
-	make_clip(	"_solidify_bridgepier16",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"7270 6326 200" );
-	make_clip(	"_solidify_bridgepier17",	"Everyone",	1,	"-42 -280 -8",		"42 280 177",		"8694 6326 200" );
-	make_clip(	"_booster_lighta",		"Survivors",	1,	"-55 -55 -17",		"55 55 2121",		"8755 5850 978.9" );
-	make_clip(	"_booster_fence",		"Survivors",	1,	"-99 -99 0",		"99 99 1337",		"8422 5899 831" );
-	make_clip(	"_booster_generatora",		"Survivors",	1,	"-32 -32 -17",		"32 32 2121",		"8362 5702 753" );
-	make_clip(	"_booster_lightb",		"Survivors",	1,	"-55 -55 -17",		"55 55 2121",		"9352 5101 977.9" );
-	make_clip(	"_booster_lightc",		"Survivors",	1,	"-55 -55 -17",		"55 55 2121",		"9670 4237 977.9" );
-	make_clip(	"_booster_lightd",		"Survivors",	1,	"-55 -55 -17",		"55 55 2121",		"9856 3385 962.9" );
-	make_clip(	"_booster_sign",		"Survivors",	1,	"-150 -45 -17",		"150 45 2121",		"9418 3972 798.3" );
-	make_clip(	"_booster_acunit",		"Survivors",	1,	"-35 -65 -17",		"35 65 2121",		"8352 1700 474.9" );
-	make_clip(	"_booster_rollupdoor",		"Survivors",	1,	"-13 -70 0",		"13 70 2121",		"8331 1888 346.3" );
-	make_clip(	"_booster_generatorb",		"Survivors",	1,	"-32 -32 -17",		"32 32 2121",		"8526 3995 485.8" );
-	make_clip(	"_booster_generatorc",		"Survivors",	1,	"-32 -32 -17",		"32 32 2121",		"8245 3460 485.8" );
-	make_clip(	"_booster_tree",		"Survivors",	1,	"-110 -170 -17",	"120 140 2121",		"7975 2389 434" );
-	make_clip( "_cliprework_jeepbean", "Survivors", 1, "-339 -243 0", "528 260 1258", "8967 6328 790" );
-	make_clip( "_endrubble_smoother", "Everyone", 1, "-8 -41 0", "8 38 8", "8209 6208 456", "45 0 0" );
-	make_clip( "_ramp_smoother", "Everyone", 1, "-6 -42 0", "3 42 2", "8041 4102 180", "-30 -30 0" );
-	make_clip( "_clipextend_endchopper", "Survivors", 1, "-125 -506 0", "135 299 1852", "7383 3797 1199", "0 25 0" );
+	make_clip( "_antiboost_finaleskip",		"Survivors",	1, "-216 -295 -96",	"216 330 9001",	"-12017 6306 779" );
+	make_clip( "_permstuck_semiwheels",		"Everyone",		1, "-45 -30 -75",	"45 30 75",		"5929 6072 475" );
+	make_clip( "_endfence_curvejump",		"Survivors",	1, "-112 -80 -180",	"112 80 2400",	"9552 6640 556" );
+	make_clip( "_endfence_commonhop",		"Survivors",	1, "-24 -240 -55",	"24 240 17",	"9480 6320 705" );
+	make_clip( "_bunnyhop_fence",			"Survivors",	1, "-68 -71 -163",	"68 80 163",	"-11827 6526 611" );
+	make_clip( "_solidify_bridgepier01",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-11786 6325 200" );
+	make_clip( "_solidify_bridgepier03",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-9226 6325 200" );
+	make_clip( "_solidify_bridgepier02",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-11274 6325 200" );
+	make_clip( "_solidify_bridgepier04",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-8586 6325 200" );
+	make_clip( "_solidify_bridgepier05",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-7434 6325 200" );
+	make_clip( "_solidify_bridgepier06",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-6154 6325 200" );
+	make_clip( "_solidify_bridgepier07",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-4618 6325 200" );
+	make_clip( "_solidify_bridgepier08",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-3082 6325 200" );
+	make_clip( "_solidify_bridgepier09",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-1546 6325 200" );
+	make_clip( "_solidify_bridgepier10",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"-10 6325 200" );
+	make_clip( "_solidify_bridgepier11",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"1526 6325 200" );
+	make_clip( "_solidify_bridgepier12",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"3062 6325 200" );
+	make_clip( "_solidify_bridgepier13",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"3990 6326 200" );
+	make_clip( "_solidify_bridgepier14",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"4599 6326 200" );
+	make_clip( "_solidify_bridgepier15",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"6662 6326 200" );
+	make_clip( "_solidify_bridgepier16",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"7270 6326 200" );
+	make_clip( "_solidify_bridgepier17",	"Everyone",		1, "-42 -280 -8",	"42 280 177",	"8694 6326 200" );
+	make_clip( "_booster_lighta",			"Survivors",	1, "-55 -55 -17",	"55 55 2121",	"8755 5850 978.9" );
+	make_clip( "_booster_fence",			"Survivors",	1, "-99 -99 0",		"99 99 1337",	"8422 5899 831" );
+	make_clip( "_booster_generatora",		"Survivors",	1, "-32 -32 -17",	"32 32 2121",	"8362 5702 753" );
+	make_clip( "_booster_lightb",			"Survivors",	1, "-55 -55 -17",	"55 55 2121",	"9352 5101 977.9" );
+	make_clip( "_booster_lightc",			"Survivors",	1, "-55 -55 -17",	"55 55 2121",	"9670 4237 977.9" );
+	make_clip( "_booster_lightd",			"Survivors",	1, "-55 -55 -17",	"55 55 2121",	"9856 3385 962.9" );
+	make_clip( "_booster_sign",				"Survivors",	1, "-150 -45 -17",	"150 45 2121",	"9418 3972 798.3" );
+	make_clip( "_booster_acunit",			"Survivors",	1, "-35 -65 -17",	"35 65 2121",	"8352 1700 474.9" );
+	make_clip( "_booster_rollupdoor",		"Survivors",	1, "-13 -70 0",		"13 70 2121",	"8331 1888 346.3" );
+	make_clip( "_booster_generatorb",		"Survivors",	1, "-32 -32 -17",	"32 32 2121",	"8526 3995 485.8" );
+	make_clip( "_booster_generatorc",		"Survivors",	1, "-32 -32 -17",	"32 32 2121",	"8245 3460 485.8" );
+	make_clip( "_booster_tree",				"Survivors",	1, "-110 -170 -17",	"120 140 2121",	"7975 2389 434" );
+	make_clip( "_cliprework_jeepbean",		"Survivors",	1, "-339 -243 0",	"528 260 1258",	"8967 6328 790" );
+	make_clip( "_endrubble_smoother",		"Everyone",		1, "-8 -41 0",		"8 38 8",		"8209 6208 456",	"45 0 0" );
+	make_clip( "_ramp_smoother",			"Everyone",		1, "-6 -42 0",		"3 42 2",		"8041 4102 180",	"-30 -30 0" );
+	make_clip( "_clipextend_endchopper",	"Survivors",	1, "-125 -506 0",	"135 299 1852",	"7383 3797 1199",	"0 25 0" );
+	patch_outro( "relay_leave_heli", "ptemplate_finale" );
 
 	if ( g_BaseMode == "versus" )
 	{
@@ -52,19 +53,19 @@ function DoRoundFixes()
 
 		// FIXES
 
-		make_clip(	"_bunnyhop_girder",		"Survivors",	1,	"-610 -17 -101",	"40 24 256",		"-5528 6568 860" );
-		make_clip(	"_solidify_girderleft",		"Survivors",	1,	"-500 0 0",		"0 40 50",		"4544 6600 750" );
-		make_clip(	"_solidify_girderright",	"Survivors",	1,	"-500 -40 0",		"0 0 50",		"4544 6050 750" );
-		make_clip( "_solidify_stuckwarp1", "Survivors", 1, "-26 -10 -37", "61 11 32", "4152 6617 729" );
-		make_clip( "_solidify_stuckwarp2", "Survivors", 1, "-26 -10 -37", "61 11 32", "4152 6034 729" );
-		make_clip( "_solidify_stuckwarp3", "Survivors", 1, "-86 -10 -37", "15 11 32", "4502 6034 729" );
-		make_clip( "_solidify_stuckwarp4", "Survivors", 1, "-86 -10 -37", "15 11 32", "4502 6617 729" );
-		make_clip(	"_solidify_alt_girderleft",	"Survivors",	1,	"-500 0 0",		"0 40 50",		"7187 6600 750" );
-		make_clip(	"_solidify_alt_girderright",	"Survivors",	1,	"-500 -40 0",		"0 0 50",		"7187 6050 750" );
-		make_clip( "_solidify_alt_stuckwarp1", "Survivors", 1, "-26 -10 -37", "61 11 32", "6795 6617 729" );
-		make_clip( "_solidify_alt_stuckwarp2", "Survivors", 1, "-26 -10 -37", "61 11 32", "6795 6034 729" );
-		make_clip( "_solidify_alt_stuckwarp3", "Survivors", 1, "-86 -10 -37", "15 11 32", "7145 6034 729" );
-		make_clip( "_solidify_alt_stuckwarp4", "Survivors", 1, "-86 -10 -37", "15 11 32", "7145 6617 729" );
+		make_clip( "_bunnyhop_girder",			"Survivors",	1, "-610 -17 -101",	"40 24 256",	"-5528 6568 860" );
+		make_clip( "_solidify_girderleft",		"Survivors",	1, "-500 0 0",		"0 40 50",		"4544 6600 750" );
+		make_clip( "_solidify_girderright",		"Survivors",	1, "-500 -40 0",	"0 0 50",		"4544 6050 750" );
+		make_clip( "_solidify_stuckwarp1",		"Survivors",	1, "-26 -10 -37",	"61 11 32",		"4152 6617 729" );
+		make_clip( "_solidify_stuckwarp2",		"Survivors",	1, "-26 -10 -37",	"61 11 32",		"4152 6034 729" );
+		make_clip( "_solidify_stuckwarp3",		"Survivors",	1, "-86 -10 -37",	"15 11 32",		"4502 6034 729" );
+		make_clip( "_solidify_stuckwarp4",		"Survivors",	1, "-86 -10 -37",	"15 11 32",		"4502 6617 729" );
+		make_clip( "_solidify_alt_girderleft",	"Survivors",	1, "-500 0 0",		"0 40 50",		"7187 6600 750" );
+		make_clip( "_solidify_alt_girderright",	"Survivors",	1, "-500 -40 0",	"0 0 50",		"7187 6050 750" );
+		make_clip( "_solidify_alt_stuckwarp1",	"Survivors",	1, "-26 -10 -37",	"61 11 32",		"6795 6617 729" );
+		make_clip( "_solidify_alt_stuckwarp2",	"Survivors",	1, "-26 -10 -37",	"61 11 32",		"6795 6034 729" );
+		make_clip( "_solidify_alt_stuckwarp3",	"Survivors",	1, "-86 -10 -37",	"15 11 32",		"7145 6034 729" );
+		make_clip( "_solidify_alt_stuckwarp4",	"Survivors",	1, "-86 -10 -37",	"15 11 32",		"7145 6617 729" );
 	}
 	if ( g_BaseMode == "survival" )
 	{
@@ -72,11 +73,10 @@ function DoRoundFixes()
 
 		// FIXES
 
-		make_clip( "_survivalbig_skyboxcap", "Survivors", 1, "-2388 -2396 0", "1787 2736 32", "8074 3332 1536" );
-
-		make_clip(	"_booster_helipada",		"Survivors",	1,	"-1640 -17 -240",	"32 17 2882",		"7481 2202 175" );
-		make_clip(	"_booster_helipadb",		"Survivors",	1,	"-17 -1800 -240",	"17 1240 2882",		"5856 4019 176" );
-		make_clip(	"_booster_helipadc",		"Survivors",	1,	"-1640 -17 -240",	"1240 17 2882",		"7479 5276 176" );
+		make_clip( "_survivalbig_skyboxcap",	"Survivors",	1, "-2388 -2396 0",		"1787 2736 32",	"8074 3332 1536" );
+		make_clip( "_booster_helipada",			"Survivors",	1, "-1640 -17 -240",	"32 17 2882",	"7481 2202 175" );
+		make_clip( "_booster_helipadb",			"Survivors",	1, "-17 -1800 -240",	"17 1240 2882",	"5856 4019 176" );
+		make_clip( "_booster_helipadc",			"Survivors",	1, "-1640 -17 -240",	"1240 17 2882",	"7479 5276 176" );
 	}
 
 	if ( HasPlayerControlledZombies() )


### PR DESCRIPTION
This PR fixes the outro of gauntlet finales when the finale is skipped. The source of the issue is that gauntlet finales use a point_template to spawn the trigger_finale (for some reason?) instead of just enabling it after a first button is pressed. Therefore, if the rescue trigger is reached without the first button ever being pressed, the outro sequence and credits break. For example, the survivors wouldn't be teleported to the escape isps, and the stats would be zeroed. **(1)** This PR adds a check for the finale in the outro relay to enforce that trigger_finale exists when FinaleEscapeForceSurvivorPositions and FinaleEscapeFinished are triggered. Since these actions should happen after the trigger_finale is spawned, **(2)** I took the opportunity to fix the survivor teleportation in c13m4: the warp now happens when the screen is completely faded black instead of happening immediately 😄. I also improved tabulation in the c5m5 and c13m4 fixes files.