### PR TITLE
Update Death's Door (community5.nut)

### DIFF
--- a/root/scripts/vscripts/community5.nut
+++ b/root/scripts/vscripts/community5.nut
@@ -118,6 +118,16 @@ function OnGameEvent_bot_player_replace( params )
 	StopSoundOn( "Player.Heartbeat", player );
 }
 
+function OnGameEvent_player_complete_sacrifice( params )
+{
+	local player = GetPlayerFromUserID( params["userid"] );
+	if ( !player )
+		return;
+
+	NetProps.SetPropInt( player, "m_takedamage", 0 );
+	NetProps.SetPropInt( player, "m_isIncapacitated", 1 );
+}
+
 if ( !Director.IsSessionStartMap() )
 {
 	function PlayerSpawnDeadAfterTransition( userid )


### PR DESCRIPTION
- Fixed an issue that caused the mission to fail for Sacrifice type finales when the player presses the final button, by adding a workaround.