### PR TITLE
Fix mission fail after players lose control of their characters

### DIFF
--- a/root/scripts/vscripts/community/mapfixes.nut
+++ b/root/scripts/vscripts/community/mapfixes.nut
@@ -243,6 +243,13 @@ local s_CommunityUpdate =
 			EntFire( g_UpdateName + "_hittable_rock",	"Kill", null, 0.1 );
 		}
 
+		if ( IsMissionFinalMap() )
+		{
+			local finale = Entities.FindByClassname( null, "trigger_finale" );
+
+			EntityOutputs.AddOutput( finale, "EscapeVehicleLeaving", "!self", "RunScriptCode", "Convars.SetValue( \"sb_all_bot_game\", 1 );", 0.0, 1 );
+		}
+
 		// Fix forklifts so they can start obstructed but still be destroyed.
 
 		local forklift = null;

--- a/root/scripts/vscripts/community/mapfixes.nut
+++ b/root/scripts/vscripts/community/mapfixes.nut
@@ -245,9 +245,12 @@ local s_CommunityUpdate =
 
 		if ( IsMissionFinalMap() )
 		{
-			local finale = Entities.FindByClassname( null, "trigger_finale" );
+			local finale = Entities.FindByClassname( null, "trigger_finale" ), code;
 
-			EntityOutputs.AddOutput( finale, "EscapeVehicleLeaving", "!self", "RunScriptCode", "Convars.SetValue( \"sb_all_bot_game\", 1 );", 0.0, 1 );
+			code = "sb_all_bot_game <- Convars.GetStr( \"sb_all_bot_game\" ); Convars.SetValue( \"sb_all_bot_game\", 1 );"
+			EntityOutputs.AddOutput( finale, "EscapeVehicleLeaving", "!self", "RunScriptCode", code, 0.0, 1 );
+			code = "if ( \"sb_all_bot_game\" in this ) Convars.SetValue( \"sb_all_bot_game\", sb_all_bot_game );"
+			EntityOutputs.AddOutput( finale, "FinaleLost", "!self", "RunScriptCode", code, 0.0, 1 );
 		}
 
 		// Fix forklifts so they can start obstructed but still be destroyed.


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modified live game files first.

## What exactly is changed and why?

This PR simply configures `trigger_finale`s to fire an output that sets the cvar `sb_all_bot_game` to 1 after players lose control of their characters. This is to prevent an issue where the mission would fail if the only human players die **for whatever reason** in the outro. The cvar is reset when the credits end or when the outro is forcefully interrupted, by `!restart` for example, (via another output). This would render PR #277 obsolete and would be an alternative, more general, fix to #275.

**Extra motivations:**

This fix is deliberately very general as it aims to tackle the fundamental issue that players should never lose if the fail reason was not caused by their incompetence (if **everyone** dies or gets incapacitated in the outro, then the mission would still fail as expected). This would also fix custom finales besides sacrifice-type ones and also the coop + B&W Bill combo. For example, a custom finale that has an "accident" happen to the survivors during the outro after they get rescued. Suppose that the outro picks half (or none) of the remaining survivors to kill. If that half contains the only human players, then the fail issue would be avoided. I believe this issue fix should not be delegated to all map makers. If it's obscure enough that The Sacrifice doesn't address it, then why should random mappers be expected to deal with it?

Note also that this is not a complete fix to The Sacrifice finale as it would still be desirable to have an adaptable, sometimes shorter, outro sequence if the sacrificed person is allowed to die; or it would be desirable to have a trigger damage override akin to what #277 did to make sure the sacrificed person doesn't die (to match the lore that Bill crawls to the generator room...). These latter fixes, however, should be map specific patches.

## Is there anything specific that needs review?

No.

## Does this address any open issues?

No.