### PR TITLE
Rainy Infected Gradient Restored

### DIFF
--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 }

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1

--- a/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_tanktop_jeans_rain_wounded_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cif_tanktop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_jeans_rain_wounded_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_tankTop_jeans_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 }

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1

--- a/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_tanktop_overalls_rain_wounded_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_deepsouth_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_rain"
 $DETAILSCALE 6
 $phongboost 2
 $WOUNDED 1


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

Restores the rainy color gradient that I removed in a previous pull request due to the change not working as intended.

Several months ago, when I was updating the rainy infected vmt files, I removed the "ci_gradient_palette_rain" attribute so that they would use the default color gradient like the other infected.

However, I've since made the discovery that the rainy infected models don't appear to be able to use the default color gradient correctly. (This is most noticable with their pants color). Due to this, I am restoring their original palette colors.

## Is there anything specific that needs review? (Consider marking as a draft.)

No

## Does this address any open issues?

No