### PR TITLE
Consistent melee "damage"

### DIFF
--- a/root/scripts/melee/baseball_bat.txt
+++ b/root/scripts/melee/baseball_bat.txt
@@ -1,0 +1,165 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"0.75"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_bat.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_bat.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	"decapitates" "1"
+	
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_BAT"
+	"activity_walk" 	"ACT_WALK_BAT"
+	"activity_run" 		"ACT_RUN_BAT"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_BAT"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_BAT"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_BAT"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_BAT"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_BAT"
+	"activity_runinjured"   "ACT_RUN_INJURED_BAT"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_BAT"
+	"activity_walkcalm"	"ACT_WALK_BAT"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_BAT"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_BAT"
+
+	"activity_attackprimary"  	"ACT_SHOOT_E2W_BAT"
+	"activity_attacksecondary"	"ACT_SHOOT_SECONDARY_BAT"
+
+	"activity_deploy"		"ACT_DEPLOY_GREN"
+
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+	
+	"addon_attachment"		"melee"
+	"addon_offset"			"-10 0 1"
+	"addon_angles"			"90 0 0"	
+	
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"Bat.Miss"
+		"melee_hit"		"Bat.ImpactFlesh"
+		"melee_hit_world"	"Bat.ImpactWorld"
+	}
+		
+	// Force vector to apply to the ragdolls of zombies we kill
+	"force_dir"		"0 0 1000"
+	
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"1.6"
+	
+	// possible format for custom directions for subsequent attacks
+
+// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"slash1"
+		{
+			"startdir"		"E"
+			"enddir"			"W"
+			"duration"		"0.9"
+			"starttime"		"0.1"
+			"endtime"			"0.34"
+			"activity"		"ACT_VM_HITCENTER"
+			"player_activity"	"ACT_SHOOT_E2W_BAT"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_BAT"
+			"force_dir"		"15 -40 0"
+		}
+			"slash2"
+		{
+			"startdir"		"NW"
+			"enddir"			"SE"
+			"duration"		"0.9"
+			"starttime"		"0.0"
+			"endtime"			"0.2"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_W2E_BAT"
+			"player_activity_idle"	"ACT_SHOOT_W2E_IDLE_BAT"
+			"force_dir"		"15 40 -10"
+		}
+			"slash3"
+		{
+			"startdir"		"NE"
+			"enddir"			"SW"
+			"duration"		"0.9"
+			"starttime"		"0.0"
+			"endtime"			"0.2"
+			"activity"		"ACT_VM_HITRIGHT"
+			"player_activity"	"ACT_SHOOT_E2W_BAT"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_BAT"
+			"force_dir"		"15 -40 -10"
+		}
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"E"
+				"enddir"		"W"
+				"duration"		"1" //37 frames @ 37fps
+				"starttime"		"0.46" //starts at 17
+				"endtime"		".78" //ends at 22
+				"activity"		"ACT_VM_SWINGHARD"
+				"player_activity"	"ACT_SHOOT_STRONG_BAT"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_BAT"
+				"force_dir"		"22 -30 35"
+		}
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_BAT"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_BAT"
+		}	
+	}	
+	
+
+
+
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_baseball_bat"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/baseball_bat.txt
+++ b/root/scripts/melee/baseball_bat.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/electric_guitar.txt
+++ b/root/scripts/melee/electric_guitar.txt
@@ -1,0 +1,142 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"1.0"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_electric_guitar.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_electric_guitar.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+	
+	"decapitates" "1"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_GUITAR"
+	"activity_walk" 	"ACT_WALK_GUITAR"
+	"activity_run" 		"ACT_RUN_GUITAR"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_GUITAR"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_GUITAR"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_GUITAR"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_GUITAR"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_GUITAR"
+	"activity_runinjured"   "ACT_RUN_INJURED_GUITAR"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_GUITAR"
+	"activity_walkcalm"	"ACT_WALK_GUITAR"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_GUITAR"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_GUITAR"
+
+	"activity_deploy"		"ACT_DEPLOY_RIFLE"
+	
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+
+	"addon_attachment"		"melee"
+	"addon_offset"			"4 0 0"
+	"addon_angles"			"175 100 95"	
+		
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"Guitar.Miss"
+		"melee_hit"		"Guitar.ImpactFlesh"
+		"melee_hit_world"	"Guitar.ImpactWorld"
+	}
+		
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"1.6"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"slash1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1.23"
+			"starttime"		"0.1"
+			"endtime"		"0.33"
+			"activity"		"ACT_VM_PRIMARYATTACK"
+			"player_activity"	"ACT_SHOOT_E2W_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_GUITAR"
+			"force_dir"		"0 -15 0"
+		}	
+		"slash2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.23"
+			"starttime"		"0.1"
+			"endtime"		"0.33"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_E2W_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_GUITAR"
+			"force_dir"		"0 15 0"
+		}		
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"N"
+				"enddir"		"S"
+				"duration"		"1.24"
+				"starttime"		"0.35"
+				"endtime"		"0.60"
+				"activity"		"ACT_VM_SWINGHARD"
+				"player_activity"	"ACT_SHOOT_STRONG_AXE"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_AXE"
+				"force_dir"		"0 0 18"
+		}
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_GUITAR"
+		}	
+	}	
+	
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_electric_guitar"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/electric_guitar.txt
+++ b/root/scripts/melee/electric_guitar.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/fireaxe.txt
+++ b/root/scripts/melee/fireaxe.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/fireaxe.txt
+++ b/root/scripts/melee/fireaxe.txt
@@ -1,0 +1,140 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"1.0"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_fireaxe.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_fireaxe.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"4"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	"decapitates" "1"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_AXE"
+	"activity_walk" 	"ACT_WALK_AXE"
+	"activity_run" 		"ACT_RUN_AXE"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_AXE"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_AXE"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_AXE"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_AXE"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_AXE"
+	"activity_runinjured"   "ACT_RUN_INJURED_AXE"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_AXE"
+	"activity_walkcalm"	"ACT_WALK_AXE"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_AXE"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_AXE"
+	"activity_deploy"		"ACT_DEPLOY_RIFLE"
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+
+	"addon_attachment"		"melee"
+	"addon_offset"			"20 -3 1"
+	"addon_angles"			"0 80 -90"
+
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"Axe.Miss"
+		"melee_hit"		"Axe.ImpactFlesh"
+		"melee_hit_world"	"Axe.ImpactWorld"
+	}
+		
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"1.6"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"slash1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1.23"
+			"starttime"		"0.1"
+			"endtime"		"0.33"
+			"activity"		"ACT_VM_PRIMARYATTACK"
+			"player_activity"	"ACT_SHOOT_E2W_AXE"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_AXE"
+			"force_dir"		"5 -5 10"
+		}	
+		"slash2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.23"
+			"starttime"		"0.1"
+			"endtime"		"0.33"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_W2E_AXE"
+			"player_activity_idle"	"ACT_SHOOT_W2E_IDLE_AXE"
+			"force_dir"		"5 5 10"
+		}		
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"N"
+				"enddir"		"S"
+				"duration"		"1.24"
+				"starttime"		"0.35"
+				"endtime"		"0.60"
+				"activity"		"ACT_VM_SWINGHARD"
+				"player_activity"	"ACT_SHOOT_STRONG_AXE"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_AXE"
+				"force_dir"		"10 0 6"
+		}
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_AXE"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_AXE"
+		}	
+	}	
+	
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_fireaxe"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/frying_pan.txt
+++ b/root/scripts/melee/frying_pan.txt
@@ -1,0 +1,144 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"0.75"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_frying_pan.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_frying_pan.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	// Third person animations
+	"activity_idle"					"ACT_IDLE_FRYINGPAN"
+	"activity_walk" 				"ACT_WALK_FRYINGPAN"
+	"activity_run" 					"ACT_RUN_FRYINGPAN"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_FRYINGPAN"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_FRYINGPAN"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 		"ACT_RUN_CROUCH_FRYINGPAN"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_FRYINGPAN"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_FRYINGPAN"
+	"activity_runinjured"   "ACT_RUN_INJURED_FRYINGPAN"
+	"activity_idlecalm" 		"ACT_IDLE_CALM_FRYINGPAN"
+	"activity_walkcalm"			"ACT_WALK_FRYINGPAN"  	// there isn't a calm walk with` an axe
+	"activity_runcalm" 			"ACT_RUN_FRYINGPAN"		// there isn't a calm run with an axe
+	"activity_pulled" 			"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 				"ACT_JUMP_FRYINGPAN"
+
+	"activity_attackprimary"  	"ACT_VM_PRIMARY_ATTACK"
+
+	"activity_attacksecondary"	"ACT_VM_SECONDARY_ATTACK"
+
+	"activity_deploy"		"ACT_DEPLOY_GREN"
+
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_MELEE"
+	
+	"addon_attachment"		"melee"
+	"addon_offset"			"-8 0 2"
+	"addon_angles"			"168 -270 90"	
+	
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"Pan.Miss"
+		"melee_hit"		"Pan.ImpactFlesh"
+		"melee_hit_world"	"Pan.ImpactWorld"
+	}
+
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"1.6"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"bonk1"
+		{
+		"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"0.75"
+			"starttime"		"0.15"
+			"endtime"		"0.36"
+			"activity"		"ACT_VM_PRIMARYATTACK"
+			"player_activity" "ACT_SHOOT_N2S_FRYINGPAN"
+			"player_activity_idle"	"ACT_SHOOT_N2S_IDLE_FRYINGPAN"
+			"force_dir"		"50 -30 0"
+		}	
+		"bonk2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"0.5"
+			"starttime"		"0.1"
+			"endtime"		"0.3"
+			"activity"							"ACT_VM_HITLEFT"
+			"player_activity" 			"ACT_SHOOT_W2E_FRYINGPAN"
+			"player_activity_idle"	"ACT_SHOOT_W2E_IDLE_FRYINGPAN"
+			"force_dir"		"50 -30 0"
+		}		
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"S"
+				"enddir"		"N"
+				"duration"		"1.24"
+				"starttime"		"0.35"
+				"endtime"		"0.60"
+				"activity"		"ACT_VM_SWINGHARD"
+				"player_activity"	"ACT_SHOOT_STRONG_FRYINGPAN"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_FRYINGPAN"
+				"force_dir"		"60 0 60"
+		}
+	}
+		"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.3"
+			"starttime"		"0.15"
+			"endtime"		"0.3"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity" "ACT_SHOOT_SECONDARY_FRYINGPAN"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_FRYINGPAN"
+		}	
+	}
+	
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_frying_pan"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/frying_pan.txt
+++ b/root/scripts/melee/frying_pan.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/golfclub.txt
+++ b/root/scripts/melee/golfclub.txt
@@ -1,0 +1,149 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"0.75"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_golfclub.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_golfclub.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	"decapitates" "1"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_BAT"
+	"activity_walk" 	"ACT_WALK_BAT"
+	"activity_run" 		"ACT_RUN_BAT"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_BAT"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_BAT"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_BAT"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_BAT"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_BAT"
+	"activity_runinjured"   "ACT_RUN_INJURED_BAT"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_BAT"
+	"activity_walkcalm"	"ACT_WALK_BAT"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_BAT"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_BAT"
+
+	"activity_attackprimary"  	"ACT_SHOOT_E2W_KATANA"
+	"activity_attacksecondary"	"ACT_SHOOT_SECONDARY_BAT"
+
+	"activity_deploy"		"ACT_DEPLOY_GREN"
+
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+	
+	"addon_attachment"		"melee"
+	"addon_offset"			"-4 0 1"
+	"addon_angles"			"40 90 95"
+
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"GolfClub.Miss"
+		"melee_hit"		"GolfClub.ImpactFlesh"
+		"melee_hit_world"	"GolfClub.ImpactWorld"
+	}
+
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"0.8"
+	
+	// Attack animations (primary and secondary)
+
+	"primaryattacks"
+	{
+		"slash1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1"
+			"starttime"		"0.1"
+			"endtime"		"0.25"
+			"activity"		"ACT_VM_HITCENTER"
+			"player_activity"	"ACT_SHOOT_E2W_KATANA"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_KATANA"
+			"force_dir"		"4 -10 0"
+		}
+			"slash2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.3"
+			"starttime"		"0.0"
+			"endtime"		"0.2"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_W2E_KATANA"
+			"player_activity_idle"	"ACT_SHOOT_W2E_IDLE_KATANA"
+			"force_dir"		"4 10 -10"
+		}
+		
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"E"
+				"enddir"		"W"
+				"duration"		"1" //37 frames @ 37fps
+				"starttime"		"0.46" //starts at 17
+				"endtime"		".78" //ends at 22
+				"activity"		"ACT_VM_SWINGHARD"
+				"player_activity"	"ACT_SHOOT_STRONG_BAT"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_BAT"
+				"force_dir"		"6 -9 10"
+		}
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_BAT"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_BAT"
+		}	
+	}	
+	
+
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+			"file"		"vgui/hud/icon_golfclub"
+			"width"		"128"
+			"height"	"64"	
+		}
+	}		
+
+}
+
+

--- a/root/scripts/melee/golfclub.txt
+++ b/root/scripts/melee/golfclub.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/katana.txt
+++ b/root/scripts/melee/katana.txt
@@ -1,0 +1,154 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"0.8"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_katana.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_katana.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"4"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	"decapitates" "1"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_BAT"
+	"activity_walk" 	"ACT_WALK_BAT"
+	"activity_run" 		"ACT_RUN_BAT"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_BAT"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_BAT"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_BAT"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_BAT"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_BAT"
+	"activity_runinjured"   "ACT_RUN_INJURED_BAT"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_BAT"
+	"activity_walkcalm"	"ACT_WALK_BAT"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_BAT"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_BAT"
+
+	"activity_attackprimary"  	"ACT_SHOOT_E2W_KATANA"
+	"activity_attacksecondary"	"ACT_SHOOT_SECONDARY_BAT"
+
+	"activity_deploy"		"ACT_DEPLOY_GREN"
+
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+	
+	"addon_attachment"		"melee"
+	"addon_offset"			"-4 0 1"
+	"addon_angles"			"40 90 95"
+
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"			"Katana.Miss"
+		"melee_hit"			"Katana.ImpactFlesh"
+		"melee_hit_world"		"Katana.ImpactWorld"
+	}
+
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"0.8"
+	
+	// Attack animations (primary and secondary)
+
+	"primaryattacks"
+	{
+		"slash1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1"
+			"starttime"		"0.1"
+			"endtime"		"0.25"
+			"activity"		"ACT_VM_HITCENTER"
+			"player_activity"	"ACT_SHOOT_E2W_KATANA"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_KATANA"
+			"force_dir"		"4 -10 0"
+		}
+			"slash2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.3"
+			"starttime"		"0.0"
+			"endtime"		"0.2"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_W2E_KATANA"
+			"player_activity_idle"	"ACT_SHOOT_W2E_IDLE_KATANA"
+			"force_dir"		"4 10 -10"
+		}
+		
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"E"
+				"enddir"		"W"
+				"duration"		"1" //37 frames @ 37fps
+				"starttime"		"0.46" //starts at 17
+				"endtime"		".78" //ends at 22
+				"activity"		"ACT_VM_SWINGHARD"
+				"player_activity"	"ACT_SHOOT_STRONG_BAT"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_BAT"
+				"force_dir"		"6 -9 10"
+		}
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_BAT"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_BAT"
+		}	
+	}	
+	
+
+
+
+
+
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_katana"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}
+
+

--- a/root/scripts/melee/katana.txt
+++ b/root/scripts/melee/katana.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/pitchfork.txt
+++ b/root/scripts/melee/pitchfork.txt
@@ -1,0 +1,141 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"0.88"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_pitchfork.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_pitchfork.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"70"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"4"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	"decapitates" "0"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_AXE"
+	"activity_walk" 	"ACT_WALK_AXE"
+	"activity_run" 		"ACT_RUN_AXE"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_AXE"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_AXE"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_AXE"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_AXE"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_AXE"
+	"activity_runinjured"   "ACT_RUN_INJURED_AXE"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_AXE"
+	"activity_walkcalm"	"ACT_WALK_AXE"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_AXE"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_AXE"
+
+	"activity_deploy"		"ACT_DEPLOY_RIFLE"
+	
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+
+	"addon_attachment"		"melee"
+	"addon_offset"			"13 -1 0"
+	"addon_angles"			"175 -80 95"
+	
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"			"Pitchfork.Miss"
+		"melee_hit"			"Pitchfork.ImpactFlesh"
+		"melee_hit_world"	    	"Pitchfork.ImpactWorld"
+	}
+
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"0.8"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"slash1"
+		{
+			"startdir"		"S"
+			"enddir"		"N"
+			"duration"		".6"
+			"starttime"		"0.11"
+			"endtime"		"0.25"
+			"activity"		"ACT_VM_PRIMARYATTACK"
+			"player_activity"	"ACT_SHOOT_E2W_AXE"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_AXE"
+			"force_dir"		"10 -1 20"
+		}	
+
+		"slash2"
+		{
+			"startdir"		"SE"
+			"enddir"		"NW"
+			"duration"		".6"
+			"starttime"		"0.16"
+			"endtime"		"0.28"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_E2W_AXE"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_AXE"
+			"force_dir"		"10 -7 2"
+		}
+
+		"slash3"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		".8"
+			"starttime"		"0.22"
+			"endtime"		"0.4"
+			"activity"		"ACT_VM_HITRIGHT"
+			"player_activity"	"ACT_SHOOT_E2W_AXE"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_AXE"
+			"force_dir"		"13 10 3"
+		}		
+	}	
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.3"
+			"starttime"		"0.2"
+			"endtime"		"0.4"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity" "ACT_SHOOT_SECONDARY_AXE"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_AXE"
+		}	
+	}	
+	
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_pitchfork"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/pitchfork.txt
+++ b/root/scripts/melee/pitchfork.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"70"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/shovel.txt
+++ b/root/scripts/melee/shovel.txt
@@ -13,7 +13,7 @@ MeleeWeaponData
 	"anim_prefix"	"anim"
 	
 	// Damage per hit
-	"damage"		"80"
+	"damage"		"50"
 	
 	// Damage flag value
 	// right now you can enter the integer values, or logical OR them together

--- a/root/scripts/melee/shovel.txt
+++ b/root/scripts/melee/shovel.txt
@@ -1,0 +1,131 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"1.0"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_shovel.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_shovel.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"80"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128 | 4"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	//"decapitates" "1"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_AXE"
+	"activity_walk" 	"ACT_WALK_AXE"
+	"activity_run" 		"ACT_RUN_AXE"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_AXE"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_AXE"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_AXE"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_AXE"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_AXE"
+	"activity_runinjured"   "ACT_RUN_INJURED_AXE"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_AXE"
+	"activity_walkcalm"	"ACT_WALK_AXE"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_AXE"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_AXE"
+
+	"activity_deploy"		"ACT_DEPLOY_RIFLE"
+	
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+
+	"addon_attachment"		"melee"
+	"addon_offset"			"20 -3 1"
+	"addon_angles"			"0 80 -90"
+
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"Shovel.Miss"
+		"melee_hit"		"Shovel.ImpactFlesh"
+		"melee_hit_world"	"Shovel.ImpactWorld"
+	}
+		
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"2.1"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"bonk1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1.3"
+			"starttime"		"0.1"
+			"endtime"		"0.36"
+			"activity"		"ACT_VM_PRIMARYATTACK"
+			"player_activity"	"ACT_SHOOT_E2W_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_GUITAR"
+			"force_dir"		"10 -80 20"
+		}	
+		"bonk2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.34"
+			"starttime"		"0.07"
+			"endtime"		"0.38"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_E2W_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_GUITAR"
+			"force_dir"		"10 80 20"
+		}	
+	}	
+	"strongattacks"
+	{
+
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_AXE"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_AXE"
+		}	
+	}	
+	
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_shovel"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

All melee weapons have a stat called "Damage". This stat doesn't actually control the amount of damage dealt to enemies, but rather the damage dealt to teammatess through friendly fire. Some melee weapons have a Damage stat of "50" which means they deal 5 ff damage on Expert difficulty. For some reason, other melee weapons have a Damage stat of 70, so they do extra ff damage. This would be fine on its own, but there is no logic or reason for why the Damage numbers are as they are. For instance, the Machete (a sharp and dangerous weapon) only has a Damage stat of 50, while the frying pan has a Damage of 70. Not to mention, the Shovel (a blunt object) deals the most friendly fire of all melee weapons with a Damage stat of 80.

Because there is no "reason" for the Damage stats to be distributed how they currently are, I suggesst at least making them consistent, and having them all have a Damage stat of 50.

## Is there anything specific that needs review? (Consider marking as a draft.)

A review could go over the melee weapons and decide a more logical spread of friendly fire damage for each of them.

## Does this address any open issues?

No