### PR TITLE
Mutations Respect Map SI Count

### DIFF
--- a/root/scripts/vscripts/community1.nut
+++ b/root/scripts/vscripts/community1.nut
@@ -136,7 +136,7 @@ function OnGameEvent_round_start_post_nav( params )
 
 	if ( Director.GetMapName() == "c1m1_hotel" )
 		DirectorOptions.cm_TankLimit <- 0;
-	else if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	else if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 	else if ( Director.GetMapName() == "c7m1_docks" )
 		DirectorOptions.cm_ProhibitBosses = true;
@@ -175,7 +175,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 8;
 }
 

--- a/root/scripts/vscripts/community1.nut
+++ b/root/scripts/vscripts/community1.nut
@@ -136,7 +136,7 @@ function OnGameEvent_round_start_post_nav( params )
 
 	if ( Director.GetMapName() == "c1m1_hotel" )
 		DirectorOptions.cm_TankLimit <- 0;
-	else if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
+	else if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
 		DirectorOptions.cm_MaxSpecials = 0;
 	else if ( Director.GetMapName() == "c7m1_docks" )
 		DirectorOptions.cm_ProhibitBosses = true;
@@ -175,7 +175,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
 		DirectorOptions.cm_MaxSpecials = 8;
 }
 

--- a/root/scripts/vscripts/community2.nut
+++ b/root/scripts/vscripts/community2.nut
@@ -38,6 +38,9 @@ DirectorOptions <-
 
 function OnGameEvent_round_start_post_nav( params )
 {
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 0;
+
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
 	{
 		local population = NetProps.GetPropString( spawner, "m_szPopulation" );
@@ -47,4 +50,16 @@ function OnGameEvent_round_start_post_nav( params )
 		else
 			spawner.Kill();
 	}
+}
+
+function OnGameEvent_finale_start( params )
+{
+	if ( Director.GetMapName() == "c6m3_port" )
+		DirectorOptions.cm_MaxSpecials = 8;
+}
+
+function OnGameEvent_gauntlet_finale_start( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 8;
 }

--- a/root/scripts/vscripts/community2.nut
+++ b/root/scripts/vscripts/community2.nut
@@ -38,7 +38,7 @@ DirectorOptions <-
 
 function OnGameEvent_round_start_post_nav( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 
 	for ( local spawner; spawner = Entities.FindByClassname( spawner, "info_zombie_spawn" ); )
@@ -60,6 +60,6 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 8;
 }

--- a/root/scripts/vscripts/community3.nut
+++ b/root/scripts/vscripts/community3.nut
@@ -21,3 +21,21 @@ DirectorOptions <-
 		return 5;
 	}
 }
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 0;
+}
+
+function OnGameEvent_finale_start( params )
+{
+	if ( Director.GetMapName() == "c6m3_port" )
+		DirectorOptions.cm_MaxSpecials = 4;
+}
+
+function OnGameEvent_gauntlet_finale_start( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 4;
+}

--- a/root/scripts/vscripts/community3.nut
+++ b/root/scripts/vscripts/community3.nut
@@ -24,7 +24,7 @@ DirectorOptions <-
 
 function OnGameEvent_round_start_post_nav( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 }
 
@@ -36,6 +36,6 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 4;
 }

--- a/root/scripts/vscripts/community4.nut
+++ b/root/scripts/vscripts/community4.nut
@@ -22,7 +22,7 @@ DirectorOptions <-
 
 function OnGameEvent_round_start_post_nav( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 }
 
@@ -34,6 +34,6 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 8;
 }

--- a/root/scripts/vscripts/community4.nut
+++ b/root/scripts/vscripts/community4.nut
@@ -19,3 +19,21 @@ DirectorOptions <-
 	SpecialInitialSpawnDelayMax = 30
 	TankHitDamageModifierCoop = 0.25
 }
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 0;
+}
+
+function OnGameEvent_finale_start( params )
+{
+	if ( Director.GetMapName() == "c6m3_port" )
+		DirectorOptions.cm_MaxSpecials = 8;
+}
+
+function OnGameEvent_gauntlet_finale_start( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 8;
+}

--- a/root/scripts/vscripts/mutation1.nut
+++ b/root/scripts/vscripts/mutation1.nut
@@ -58,7 +58,7 @@ function OnGameEvent_round_start_post_nav( params )
 			spawner.Kill();
 	}
 
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
 		DirectorOptions.cm_MaxSpecials = 0;
 
 	foreach( wep, val in DirectorOptions.weaponsToConvert )
@@ -87,7 +87,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
 		DirectorOptions.cm_MaxSpecials = 2;
 }
 

--- a/root/scripts/vscripts/mutation1.nut
+++ b/root/scripts/vscripts/mutation1.nut
@@ -58,7 +58,7 @@ function OnGameEvent_round_start_post_nav( params )
 			spawner.Kill();
 	}
 
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 
 	foreach( wep, val in DirectorOptions.weaponsToConvert )
@@ -87,7 +87,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 2;
 }
 

--- a/root/scripts/vscripts/mutation16.nut
+++ b/root/scripts/vscripts/mutation16.nut
@@ -20,7 +20,7 @@ DirectorOptions <-
 
 function OnGameEvent_round_start_post_nav( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 }
 
@@ -32,6 +32,6 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 4;
 }

--- a/root/scripts/vscripts/mutation16.nut
+++ b/root/scripts/vscripts/mutation16.nut
@@ -17,3 +17,21 @@ DirectorOptions <-
 	ChargerLimit = 0
 	JockeyLimit = 0
 }
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 0;
+}
+
+function OnGameEvent_finale_start( params )
+{
+	if ( Director.GetMapName() == "c6m3_port" )
+		DirectorOptions.cm_MaxSpecials = 4;
+}
+
+function OnGameEvent_gauntlet_finale_start( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 4;
+}

--- a/root/scripts/vscripts/mutation3.nut
+++ b/root/scripts/vscripts/mutation3.nut
@@ -55,3 +55,21 @@ function Update()
 {
 	DirectorOptions.RecalculateHealthDecay();
 }
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 0;
+}
+
+function OnGameEvent_finale_start( params )
+{
+	if ( Director.GetMapName() == "c6m3_port" )
+		DirectorOptions.cm_MaxSpecials = 4;
+}
+
+function OnGameEvent_gauntlet_finale_start( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+		DirectorOptions.cm_MaxSpecials = 4;
+}

--- a/root/scripts/vscripts/mutation3.nut
+++ b/root/scripts/vscripts/mutation3.nut
@@ -58,7 +58,7 @@ function Update()
 
 function OnGameEvent_round_start_post_nav( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 }
 
@@ -70,6 +70,6 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 4;
 }

--- a/root/scripts/vscripts/mutation4.nut
+++ b/root/scripts/vscripts/mutation4.nut
@@ -10,3 +10,30 @@ DirectorOptions <-
 	cm_BaseSpecialLimit = 2
 	cm_DominatorLimit = 8
 }
+
+function OnGameEvent_round_start_post_nav( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	{
+		DirectorOptions.cm_MaxSpecials = 0;
+		DirectorOptions.cm_BaseSpecialLimit = 0;
+	}
+}
+
+function OnGameEvent_finale_start( params )
+{
+	if ( Director.GetMapName() == "c6m3_port" )
+	{
+		DirectorOptions.cm_MaxSpecials = 8;
+		DirectorOptions.cm_BaseSpecialLimit = 2;
+	}
+}
+
+function OnGameEvent_gauntlet_finale_start( params )
+{
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	{
+		DirectorOptions.cm_MaxSpecials = 8;
+		DirectorOptions.cm_BaseSpecialLimit = 2;
+	}
+}

--- a/root/scripts/vscripts/mutation4.nut
+++ b/root/scripts/vscripts/mutation4.nut
@@ -13,7 +13,7 @@ DirectorOptions <-
 
 function OnGameEvent_round_start_post_nav( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 	{
 		DirectorOptions.cm_MaxSpecials = 0;
 		DirectorOptions.cm_BaseSpecialLimit = 0;
@@ -31,7 +31,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 	{
 		DirectorOptions.cm_MaxSpecials = 8;
 		DirectorOptions.cm_BaseSpecialLimit = 2;

--- a/root/scripts/vscripts/mutation5.nut
+++ b/root/scripts/vscripts/mutation5.nut
@@ -106,7 +106,7 @@ function OnGameEvent_round_start_post_nav( params )
 			spawner.Kill();
 	}
 
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
 		DirectorOptions.cm_MaxSpecials = 0;
 
 	EntFire( "weapon_spawn", "Kill" );
@@ -122,7 +122,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
+	if ( Director.GetMapName() == "c5m5_bridge" )
 		DirectorOptions.cm_MaxSpecials = 8;
 }
 

--- a/root/scripts/vscripts/mutation5.nut
+++ b/root/scripts/vscripts/mutation5.nut
@@ -106,7 +106,7 @@ function OnGameEvent_round_start_post_nav( params )
 			spawner.Kill();
 	}
 
-	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c6m3_port" || Director.GetMapName() == "c13m4_cutthroatcreek" )
 		DirectorOptions.cm_MaxSpecials = 0;
 
 	EntFire( "weapon_spawn", "Kill" );
@@ -122,7 +122,7 @@ function OnGameEvent_finale_start( params )
 
 function OnGameEvent_gauntlet_finale_start( params )
 {
-	if ( Director.GetMapName() == "c5m5_bridge" )
+	if ( Director.GetMapName() == "c5m5_bridge" || Director.GetMapName() == "c13m4_cutthroatcreek" )
 		DirectorOptions.cm_MaxSpecials = 8;
 }
 


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

All official and community mutations that override Special Infected count will now respect the campaign missions that disable Special Infected until the finale is activated, for greater parity with the base game.

## Is there anything specific that needs review? (Consider marking as a draft.)

A review to check if any of these mutations ignored the final missions on purpose.

## Does this address any open issues?

No.