### PR TITLE
L4D1 Mudmen T-Shirt Wounded Fix

### DIFF
--- a/root/materials/models/infected/common/l4d1/common_mud_upper_02_wounded.vmt
+++ b/root/materials/models/infected/common/l4d1/common_mud_upper_02_wounded.vmt
@@ -1,6 +1,6 @@
 patch
 {
-include "materials/models/infected/common/L4D1/common_mud_upper_01.vmt"
+include "materials/models/infected/common/L4D1/common_mud_upper_02.vmt"
 insert
 {
 $wounded 1

--- a/root/materials/models/infected/common/l4d1/common_mud_upper_02_wounded.vmt
+++ b/root/materials/models/infected/common/l4d1/common_mud_upper_02_wounded.vmt
@@ -1,0 +1,8 @@
+patch
+{
+include "materials/models/infected/common/L4D1/common_mud_upper_01.vmt"
+insert
+{
+$wounded 1
+}
+}


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

The L4D1 Mudmen have two T-Shirts designs they can spawn with, problem is whenever you were to dismember them the T-Shirt would be swapped due to a small typo in `commom_mud_upper_02_wounded`. This PR simply corrects the typo to prevent more magical swap of T-Shirts

(GIFs courtesy of Wendingo's own [fix ](https://steamcommunity.com/sharedfiles/filedetails/?id=2861468906&searchtext=l4d1+mudmen)for this)
![2861468906_preview_Before-Mudders](https://user-images.githubusercontent.com/14334587/216368011-d9c9c5cd-c975-488f-be1e-febf007387cf.gif)
![2861468906_preview_After-Mudders](https://user-images.githubusercontent.com/14334587/216368055-d6135ffe-f06d-43a7-8227-d2c7b2e11946.gif)

## Is there anything specific that needs review? (Consider marking as a draft.)

Probably no? (apart from making sure the Sewermen look fine... or as fine as a man covered in sewer water can possibly look)

## Does this address any open issues?

No