### PR TITLE
scriptedmode.nut minor fix

### DIFF
--- a/root/scripts/vscripts/scriptedmode.nut
+++ b/root/scripts/vscripts/scriptedmode.nut
@@ -267,7 +267,7 @@ function MergeSessionOptionTables()
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-scriptedModeLastSlowPoll <- 0
+scriptedModeLastSlowPoll <- Time()
 scriptedModeUpdateFuncs <- []
 scriptedModeSlowPollFuncs <- []
 scriptedModeSlowPollInterval <- 3
@@ -316,7 +316,7 @@ function ScriptedMode_AddUpdate( updateFunc )
 // Adds a function to the slowpoll list
 function ScriptedMode_AddSlowPoll( updateFunc )
 {
-	if (!scriptedModeSlowPollFuncs.find(updateFunc))
+	if (scriptedModeSlowPollFuncs.find(updateFunc) == null)
 		scriptedModeSlowPollFuncs.append( updateFunc )
 	else
 		printl("You already have a SlowPoll for " + updateFunc.tostring())


### PR DESCRIPTION
## What exactly is changed and why?

Slowpoll time check logic was faulty causing slowpoll function to be called every second instead of chosen time interval (3 seconds).

Function to add slowpoll functions has incorrect check for existence of element in an array. 
if(!array.find(element)) gives wrong result when element is at index 0.

## Is there anything specific that needs review? (Consider marking as a draft.)

no

## Does this address any open issues?

no