### PR TITLE
_entHelper key in scope check fix

### DIFF
--- a/root/scripts/vscripts/scriptedmode.nut
+++ b/root/scripts/vscripts/scriptedmode.nut
@@ -376,8 +376,9 @@ _entHelper <- function ( ent, funcname )
 		}
 		else if (typeof(funcname) == "string")
 		{
-			if (funcname in ent)
-				ent[funcname]()
+			local ent_scope = ent.GetScriptScope()
+			if (ent_scope != null && funcname in ent_scope)
+				ent_scope[funcname]()
 			else if (funcname in g_ModeScript)
 				g_ModeScript[funcname](ent)
 			else if (funcname in g_MapScript)


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

Helper function _entHelp in scriptedmode.nut is checking for a key in entity's script scope incorrectly. This pr fixes it 

## Is there anything specific that needs review? (Consider marking as a draft.)

no

## Does this address any open issues?

no