### PR TITLE
Fix ill-formed `damage_flags` for the Tonfa and Shovel

### DIFF
--- a/root/scripts/melee/shovel.txt
+++ b/root/scripts/melee/shovel.txt
@@ -1,0 +1,131 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"1.0"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_shovel.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_shovel.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"80"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128 | 4"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	//"decapitates" "1"
+
+	// Third person animations
+	"activity_idle"		"ACT_IDLE_AXE"
+	"activity_walk" 	"ACT_WALK_AXE"
+	"activity_run" 		"ACT_RUN_AXE"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_AXE"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_AXE"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 	"ACT_RUN_CROUCH_AXE"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_AXE"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_AXE"
+	"activity_runinjured"   "ACT_RUN_INJURED_AXE"
+	"activity_idlecalm" 	"ACT_IDLE_CALM_AXE"
+	"activity_walkcalm"	"ACT_WALK_AXE"  	// there isn't a calm walk with an axe
+	"activity_runcalm" 	"ACT_RUN_AXE"		// there isn't a calm run with an axe
+	"activity_pulled" 	"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 	"ACT_JUMP_AXE"
+
+	"activity_deploy"		"ACT_DEPLOY_RIFLE"
+	
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_BAT"
+
+	"addon_attachment"		"melee"
+	"addon_offset"			"20 -3 1"
+	"addon_angles"			"0 80 -90"
+
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"		"Shovel.Miss"
+		"melee_hit"		"Shovel.ImpactFlesh"
+		"melee_hit_world"	"Shovel.ImpactWorld"
+	}
+		
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"2.1"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"bonk1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1.3"
+			"starttime"		"0.1"
+			"endtime"		"0.36"
+			"activity"		"ACT_VM_PRIMARYATTACK"
+			"player_activity"	"ACT_SHOOT_E2W_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_GUITAR"
+			"force_dir"		"10 -80 20"
+		}	
+		"bonk2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"1.34"
+			"starttime"		"0.07"
+			"endtime"		"0.38"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity"	"ACT_SHOOT_E2W_GUITAR"
+			"player_activity_idle"	"ACT_SHOOT_E2W_IDLE_GUITAR"
+			"force_dir"		"10 80 20"
+		}	
+	}	
+	"strongattacks"
+	{
+
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		".73"
+			"starttime"		"0.1"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+			"player_activity"	"ACT_SHOOT_SECONDARY_AXE"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_AXE"
+		}	
+	}	
+	
+	// hud textures
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_shovel"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/shovel.txt
+++ b/root/scripts/melee/shovel.txt
@@ -21,7 +21,7 @@ MeleeWeaponData
 	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
 	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
 	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
-	"damage_flags"	"128 | 4"
+	"damage_flags"	"132"
 	
 	// Rumble effect to play on 360 when we swing
 	// RUMBLE_CROWBAR_SWING = 9

--- a/root/scripts/melee/tonfa.txt
+++ b/root/scripts/melee/tonfa.txt
@@ -1,0 +1,145 @@
+MeleeWeaponData
+{
+	// Time before you can swing the weapon again
+	"refire_delay"	"0.75"
+	
+	// Model to show in firstperson
+	"viewmodel"		"models/weapons/melee/v_tonfa.mdl"
+	
+	// Model to show in thirdperson
+	"playermodel"	"models/weapons/melee/w_tonfa.mdl"
+	
+	// Animation prefix - not sure what this is used for just yet
+	"anim_prefix"	"anim"
+	
+	// Damage per hit
+	"damage"		"50"
+	
+	// Damage flag value
+	// right now you can enter the integer values, or logical OR them together
+	// supported damage types
+	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
+	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
+	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
+	"damage_flags"	"128 | 4"
+	
+	// Rumble effect to play on 360 when we swing
+	// RUMBLE_CROWBAR_SWING = 9
+	// RUMBLE_L4D_PLAYER_MELEE_HIT = 42
+	"rumble_effect"	"42"
+
+	// Third person animations
+	"activity_idle"					"ACT_IDLE_FRYINGPAN"
+	"activity_walk" 				"ACT_WALK_FRYINGPAN"
+	"activity_run" 					"ACT_RUN_FRYINGPAN"
+	"activity_crouchidle" 	"ACT_CROUCHIDLE_FRYINGPAN"
+	"activity_crouchwalk" 	"ACT_RUN_CROUCH_FRYINGPAN"  	// there isn't a crouched walk with an axe
+	"activity_crouchrun" 		"ACT_RUN_CROUCH_FRYINGPAN"
+	"activity_idleinjured"  "ACT_IDLE_INJURED_FRYINGPAN"
+	"activity_walkinjured" 	"ACT_WALK_INJURED_FRYINGPAN"
+	"activity_runinjured"   "ACT_RUN_INJURED_FRYINGPAN"
+	"activity_idlecalm" 		"ACT_IDLE_CALM_FRYINGPAN"
+	"activity_walkcalm"			"ACT_WALK_FRYINGPAN"  	// there isn't a calm walk with` an axe
+	"activity_runcalm" 			"ACT_RUN_FRYINGPAN"		// there isn't a calm run with an axe
+	"activity_pulled" 			"ACT_TERROR_PULLED_RUN_RIFLE"
+	"activity_jump" 				"ACT_JUMP_FRYINGPAN"
+
+	"activity_attackprimary"  	"ACT_SHOOT_N2S_FRYINGPAN"
+	"activity_attacksecondary"	"ACT_SHOOT_SECONDARY_FRYINGPAN"
+
+	"activity_deploy"		"ACT_DEPLOY_GREN"
+
+	"activity_shove"		"ACT_TERROR_SHOVED_FORWARD_MELEE"
+	
+	"addon_attachment"		"melee"
+	"addon_offset"			"-4 0 1"
+	"addon_angles"			"10 90 95"
+	
+		
+	// Sound data
+	// define the hit and miss sounds
+	SoundData
+	{
+		"melee_miss"			"Tonfa.Miss"
+		"melee_hit"				"Tonfa.ImpactFlesh"
+		"melee_hit_world"		"Tonfa.ImpactWorld"
+	}
+
+	// Player animation to fire, 0 = PLAYERANIMEVENT_MELEE for now
+	"player_anim_event"		"0"		// TODO - convert from string to PlayerAnimEvent_t
+	
+	// How long after attacking until the weapon enters its idle animation state
+	"weapon_idle_time"	"0.8"
+	
+	// Attack animations (primary and secondary)
+	"primaryattacks"
+	{
+		"bonk1"
+		{
+			"startdir"		"E"
+			"enddir"		"W"
+			"duration"		"1.0"
+			"starttime"		"0.16"
+			"endtime"		"0.26"
+			"activity"		"ACT_VM_PRIMARYATTACK" 
+			"player_activity" "ACT_SHOOT_N2S_FRYINGPAN"
+			"player_activity_idle"	"ACT_SHOOT_N2S_IDLE_FRYINGPAN"
+			"force_dir"		"20 7 0"
+		}	
+		"bonk2"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"0.8"
+			"starttime"		"0.0"
+			"endtime"		"0.2"
+			"activity"		"ACT_VM_HITLEFT"
+			"player_activity" "ACT_SHOOT_W2E_FRYINGPAN"
+			"player_activity_idle"	"ACT_SHOOT_W2E_IDLE_FRYINGPAN"
+			"force_dir"		"12 7 0"
+		}		
+	}	
+	"strongattacks"
+	{
+		"strongattack1"
+		{
+				"startdir"		"S"
+				"enddir"		"N"
+				"duration"		"1.24"
+				"starttime"		"0.35"
+				"endtime"		"0.60"
+				"activity"		"ACT_VM_PRIMARYATTACK"
+				"player_activity"	"ACT_SHOOT_STRONG_FRYINGPAN"
+				"player_activity_idle"	"ACT_SHOOT_STRONG_IDLE_FRYINGPAN"
+				"force_dir"		"60 0 60"
+		}
+	}
+	"secondaryattacks"
+	{
+		"shove1"
+		{
+			"startdir"		"W"
+			"enddir"		"E"
+			"duration"		"0.75"
+			"starttime"		"0.15"
+			"endtime"		"0.45"
+			"activity"		"ACT_VM_SECONDARYATTACK"
+	"player_activity" "ACT_SHOOT_SECONDARY_FRYINGPAN"
+			"player_activity_idle"	"ACT_SHOOT_SECONDARY_FRYINGPAN"
+		}	
+	}	
+	
+	// hud textures
+	//"sprite_active"		"icon_tonfa"
+	"TextureData"
+	{
+		"sprite_active"
+		{
+				"file"		"vgui/hud/icon_tonfa"
+				"x"		"0"
+				"y"		"0"
+				"width"		"128"
+				"height"	"64"	
+		}
+	}
+}

--- a/root/scripts/melee/tonfa.txt
+++ b/root/scripts/melee/tonfa.txt
@@ -21,7 +21,7 @@ MeleeWeaponData
 	//DMG_SLASH			(1 << 2) = 4 - cuts off parts of infected
 	//DMG_BURN			(1 << 3) = 8 - lights zombies on fire
 	//DMG_CLUB			(1 << 7) = 128 - knocks them back?
-	"damage_flags"	"128 | 4"
+	"damage_flags"	"132"
 	
 	// Rumble effect to play on 360 when we swing
 	// RUMBLE_CROWBAR_SWING = 9


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (`CONTRIBUTING.md` → Coordination), and if these are text or script files, then I’ll submit un-modified live game files first.

## What exactly is changed and why?

I have corrected the applicable damage flags assuming that the existing values are unintentionally ill-formed.

The key `damage_flags` in the melee scripts for both the Tonfa and Shovel has the ill-formed integer value `128 | 4` rather than the expected value `132`. The parser function for the _KeyValues_ `MeleeWeaponData` tries to parse the string value of `damage_flags` using `KeyValues::GetInt`. The string value is truncated at the pipe character by `atoi`: both melee weapons thus have only the `DMG_CLUB` attribute and lack the `DMG_SLASH` attribute.

This appears to be a developer oversight over the documentation on `damage_flags` which states that:

> …right now you can enter the integer values, or logical OR them together supported damage types.

This error appears in the Tonfa’s melee script distributed with the pre-release client [version 1.0.1.0 (2009-10-21)](https://archive.org/details/left4dead2retail) and has since replicated itself in the Shovel’s melee script bundled with the _The Last Stand_ Update.

## Is there anything specific that needs review? (Consider marking as a draft.)

I’d appreciate a second opinion on the apparent intentionality of this and the potential changes to game balance.

## Does this address any open issues?

No.