### PR TITLE
Low Shader Skyboxes Fix

### DIFF
--- a/root/materials/skybox/sky_l4d_c1_1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_1_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_1_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_1_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_1_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c1_1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_1_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_1_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_1_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_1_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_1_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_1_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_1_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c1_1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c1_1_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_1_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_1_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_2_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_2_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_2_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_2_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c1_2_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_2_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_2_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_2_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_2_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_2_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_2_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_2_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_2_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_2_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c1_2_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c1_2_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c1_2_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c1_2_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c1_2_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c1_2_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c2m1_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c2m1_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c2m1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c2m1_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c2m1_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c2m1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c2m1_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c2m1_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c2m1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c2m1_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c2m1_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c2m1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c2m1_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c2m1_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c2m1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c2m1_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c2m1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c2m1_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c2m1_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c2m1_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m1_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m1_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m1_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c4m1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m1_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m1_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m1_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m1_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m1_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m1_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m1_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m1_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c4m1_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m1_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m1_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m4_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m4_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m4_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m4_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m4_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m4_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m4_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m4_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m4_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m4_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m4_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m4_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m4_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m4_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c4m4_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c4m4_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c4m4_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c4m4_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c4m4_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c4m4_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c5_1_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c5_1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c5_1_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c5_1_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c5_1_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c5_1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c5_1_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c5_1_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c5_1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c5_1_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c5_1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c5_1_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c5_1_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c5_1_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c5_1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c5_1_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c5_1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c5_1_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c5_1_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c5_1_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c6m1_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c6m1_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c6m1_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c6m1_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c6m1_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c6m1_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c6m1_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c6m1_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c6m1_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c6m1_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c6m1_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c6m1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c6m1_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c6m1_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_c6m1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_c6m1_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_c6m1_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_c6m1_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_c6m1_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_c6m1_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_night02_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_night02_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_night02_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_night02_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_night02_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_night02_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_night02_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_night02_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_night02_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_night02_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_night02_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_night02_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_night02_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_night02_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_night02_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_night02_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_night02_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_night02_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_night02_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_night02_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_night02_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_night02_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_night02_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_night02_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_night02_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_night02_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_night02_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_night02_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_night02_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_night02_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_night02_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_night02_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_night02_hdrup"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_night02_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_night02_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_night02_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_night02_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrbk.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_predawn02_ldrbk"
+}
+$hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrbk"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_predawn02_hdrbk.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrbk.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_predawn02_ldrbk"
-}
 $hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrbk"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrdn.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_predawn02_ldrdn"
+}
+$hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrdn"
+$nofog 1
+$ignorez 1
+}

--- a/root/materials/skybox/sky_l4d_predawn02_hdrdn.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrdn.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_predawn02_ldrdn"
-}
 $hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrdn"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrft.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_predawn02_ldrft"
+}
+$hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrft"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_predawn02_hdrft.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrft.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_predawn02_ldrft"
-}
 $hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrft"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrlf.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_predawn02_ldrlf"
-}
 $hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrlf"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrlf.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrlf.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_predawn02_ldrlf"
+}
+$hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrlf"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_predawn02_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrrt.vmt
@@ -1,0 +1,11 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_predawn02_ldrrt"
+}
+$hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrrt"
+$nofog 1
+$ignorez 1
+$basetexturetransform "center 0 0 scale 1 2 rotate 0 translate 0 0"
+}

--- a/root/materials/skybox/sky_l4d_predawn02_hdrrt.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrrt.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_predawn02_ldrrt"
-}
 $hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrrt"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrup.vmt
@@ -1,9 +1,5 @@
 sky
 {
-"GPU<1"
-{
-$fallbackmaterial "skybox/sky_l4d_predawn02_ldrup"
-}
 $hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrup"
 $nofog 1
 $ignorez 1

--- a/root/materials/skybox/sky_l4d_predawn02_hdrup.vmt
+++ b/root/materials/skybox/sky_l4d_predawn02_hdrup.vmt
@@ -1,0 +1,10 @@
+sky
+{
+"GPU<1"
+{
+$fallbackmaterial "skybox/sky_l4d_predawn02_ldrup"
+}
+$hdrcompressedTexture "skybox/sky_l4d_predawn02_hdrup"
+$nofog 1
+$ignorez 1
+}


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

Even though all the L4D2 maps are compiled in HDR mode only and HDR itself can't be turned off from the video settings, Valve still had in place fallbacks to the LDR versions of the skyboxes of the Original 5 Campaigns of L4D2 (Dead Center, Dark Carnival, Swamp Fever, Hard Rain and The Parish) & The Passing for when people are playing in Low Shader settings.
The problem is, the actual materials and textures of the LDR skyboxes aren't present in the game files resulting in flat colors for the sky at best and straight-up missing textures at worst.
This PR simply removes this fallback behavior from the included vmts, allowing the skyboxes of the affected campaigns to show up properly in the Low Shader setting.
![el_cajacielo](https://user-images.githubusercontent.com/14334587/235569920-a6d2efc6-45fc-47cb-a6de-8b49397fce2e.png)
A fun little fact is that both The Sacrifice and Cold Stream already lacked this fallback behavior for their skyboxes, hence why the missing skyboxes issue wasn't present in those campaigns. On the other hand, the original L4D1 maps do have their proper LDR skyboxes in place, hence why the issue wasn't present on those maps either. 

## Is there anything specific that needs review? (Consider marking as a draft.)

Just making sure everything is in order in relation to the affected campaigns (like it was said before, this is something already done in The Sacrifice and Cold Stream and in my own testing I was unable to find any issues whatsoever).

## Does this address any open issues?

No