### PR TITLE
$bloodmaskrange Fix for Rainy Common Infected

### DIFF
--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_burning.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_bangs_rain_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_bangs_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_burning.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cif_head_longhair_rain_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cif_head_longhair_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_bald_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_bald_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain_burning.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_bald_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_bald_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_bald_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_bald_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_bald_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_bald_rain_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_bald_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_burning.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_centurion_rain_wounded_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_centurion_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_burning.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_mullet_rain_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_mullet_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 }
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain.vmt
@@ -1,0 +1,10 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_burning.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$BURNING 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $BURNING 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded.vmt
@@ -1,0 +1,11 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 }

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_head_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
-$BLOODMASKRANGE "[0.2 1.1]"
+
 $phongboost 2
 $WOUNDED 1
 $BURNING 1

--- a/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_head_shaggy_rain_wounded_burning.vmt
@@ -1,0 +1,12 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_head_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_head_shaggy_rain"
+$BLOODMASKRANGE "[0.2 1.1]"
+$phongboost 2
+$WOUNDED 1
+$BURNING 1
+}
+}


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

The VMTs of the faces of the L4D2 Rainy Common Infected have different `$bloodmaskranges` values from the ones present in the shared `ci_head_include.vmt` resulting in a mismatch between the look of the blood in the faces and the body as seen below: 
![image](https://user-images.githubusercontent.com/14334587/236373820-3d604958-ee1a-408e-8acb-077e2ccf67f3.png)

This PR fixes this by removing `$BLOODMASKRANGE "[0.2 1.1]"` line from all of the submitted VMTs fixing the issue and making the blood consistent with the rest of CIs.

## Is there anything specific that needs review? (Consider marking as a draft.)

No

## Does this address any open issues?

No