### PR TITLE
Fixed Cubemap Reflections in the Armored Delivery Van from Crash Course

### DIFF
--- a/root/materials/models/props_vehicles/deliveryvan_armor.vmt
+++ b/root/materials/models/props_vehicles/deliveryvan_armor.vmt
@@ -8,11 +8,10 @@ $phongboost 3
 $phongfresnelranges "[0.33 1.4 3]"
 $basemapluminancephongmask 1
 $envmap env_cubemap
-$envmapcontrast 4
 $envmaptint "[ 0.09 0.09 0.09 ]"
 $envmapfresnel 1
 $envmapfresnelminmaxexp "[.1 2 3]"
-$envmapmask "models/props_vehicles/deliveryvan_armor_ref"
+$normalmapalphaenvmapmask 1
 $detail "detail/metal_detail_01"
 $detailblendfactor 0.5
 $detailscale 16

--- a/root/materials/models/props_vehicles/deliveryvan_armor.vmt
+++ b/root/materials/models/props_vehicles/deliveryvan_armor.vmt
@@ -1,0 +1,21 @@
+VertexLitGeneric
+{
+$baseTexture "models\props_vehicles\psds\deliveryvan_armor"
+$bumpmap "effects\flat_normal"
+$phong 1
+$phongexponent 15
+$phongboost 3
+$phongfresnelranges "[0.33 1.4 3]"
+$basemapluminancephongmask 1
+$envmap env_cubemap
+$envmapcontrast 4
+$envmaptint "[ 0.09 0.09 0.09 ]"
+$envmapfresnel 1
+$envmapfresnelminmaxexp "[.1 2 3]"
+$envmapmask "models/props_vehicles/deliveryvan_armor_ref"
+$detail "detail/metal_detail_01"
+$detailblendfactor 0.5
+$detailscale 16
+$surfaceprop metal
+$model 1
+}

--- a/root/materials/models/props_vehicles/deliveryvan_modified.vmt
+++ b/root/materials/models/props_vehicles/deliveryvan_modified.vmt
@@ -8,11 +8,10 @@ $phongboost 3
 $phongfresnelranges "[0.33 1.4 3]"
 $basemapluminancephongmask 1
 $envmap env_cubemap
-$envmapcontrast 4
 $envmaptint "[ 0.10 0.10 0.10 ]"
 $envmapfresnel 1
 $envmapfresnelminmaxexp "[.1 2 3]"
-$envmapmask "models/props_vehicles/deliveryvan_modified_ref"
+$normalmapalphaenvmapmask 1
 $detail "detail/metal_detail_01"
 $detailblendfactor 0.5
 $detailscale 12

--- a/root/materials/models/props_vehicles/deliveryvan_modified.vmt
+++ b/root/materials/models/props_vehicles/deliveryvan_modified.vmt
@@ -1,0 +1,23 @@
+VertexLitGeneric
+{
+$basetexture "models\props_vehicles\psds\deliveryvan_modified"
+$bumpmap "effects\flat_normal"
+$phong 1
+$phongexponent 15
+$phongboost 3
+$phongfresnelranges "[0.33 1.4 3]"
+$basemapluminancephongmask 1
+$envmap env_cubemap
+$envmapcontrast 4
+$envmaptint "[ 0.10 0.10 0.10 ]"
+$envmapfresnel 1
+$envmapfresnelminmaxexp "[.1 2 3]"
+$envmapmask "models/props_vehicles/deliveryvan_modified_ref"
+$detail "detail/metal_detail_01"
+$detailblendfactor 0.5
+$detailscale 12
+$alphatest 1
+
+$surfaceprop metal
+$model 1
+}


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

As of right now, both normal and armored variants of the delivery van introduced in Crash Course make use of a combination of phong & envmap reflections but the armored van in specific had a combination of phong & envmap parameters which aren't compatible with each other (`$envmapmask` being the problematic parameter in specific) resulting in the entire vehicle being covered in reflections in places where it shouldn't.
This PR fixes that by removing `$envmapmask` (and also `$envmapcontrast` which was doing effectively nothing because of phong) and adding `$normalmapalphaenvmapmask 1` instead which, even though the name may imply otherwise, uses whatever is being used as phong mask as a envmap mask as well.

Before:
![deliveryvan_test0011](https://github.com/Tsuey/L4D2-Community-Update/assets/14334587/56a205fb-25db-4fcf-89d8-a0347b1408f0)
![deliveryvan_test0012](https://github.com/Tsuey/L4D2-Community-Update/assets/14334587/1a824233-663f-4435-8889-148ac59e5bf3)

After:
![deliveryvan_test0026](https://github.com/Tsuey/L4D2-Community-Update/assets/14334587/8f8f2f33-2e77-4554-810b-3cac419c9d93)
![deliveryvan_test0025](https://github.com/Tsuey/L4D2-Community-Update/assets/14334587/74e9321e-2c51-4821-9b1a-b4cd8ba56612)

## Is there anything specific that needs review? (Consider marking as a draft.)

The van seems to take reflections well after this change in the map used to take the screenshots and the final chapter of Crash Course, but may be worth checking if it applies to non-vanilla scenarios as well. Also, if the reflections are considered to be too strong, these can be lowered if needed.

## Does this address any open issues?

No