### PR TITLE
Update Death's Door

### DIFF
--- a/root/scripts/vscripts/community5.nut
+++ b/root/scripts/vscripts/community5.nut
@@ -2,10 +2,8 @@
 Msg("Activating Death's Door\n");
 Msg("Made by Rayman1103\n");
 
-DirectorOptions <-
+MutationOptions <-
 {
-	ActiveChallenge = 1
-
 	cm_ShouldHurry = true
 	cm_AllowPillConversion = false
 	cm_AllowSurvivorRescue = false
@@ -22,16 +20,15 @@ DirectorOptions <-
 
 	weaponsToConvert =
 	{
-		weapon_first_aid_kit =	"weapon_pain_pills_spawn"
-		weapon_adrenaline =	"weapon_pain_pills_spawn"
+		weapon_first_aid_kit = "weapon_pain_pills_spawn"
+		weapon_adrenaline = "weapon_pain_pills_spawn"
 	}
 
 	function ConvertWeaponSpawn( classname )
 	{
 		if ( classname in weaponsToConvert )
-		{
 			return weaponsToConvert[classname];
-		}
+
 		return 0;
 	}
 
@@ -44,9 +41,8 @@ DirectorOptions <-
 	function GetDefaultItem( idx )
 	{
 		if ( idx < DefaultItems.len() )
-		{
 			return DefaultItems[idx];
-		}
+
 		return 0;
 	}
 }
@@ -54,47 +50,103 @@ DirectorOptions <-
 function OnGameEvent_round_start( params )
 {
 	Convars.SetValue( "pain_pills_decay_rate", 0.0 );
+
+	for ( local player; player = Entities.FindByClassname( player, "player" ); ) // only works in restarts, which is desired
+	{
+		if ( player.IsSurvivor() && !IsPlayerABot( player ) )
+			player.GetScriptScope().HeartbeatOn = false;
+	}
 }
 
 function OnGameEvent_player_left_safe_area( params )
 {
-	DirectorOptions.TempHealthDecayRate = 0.27;
+	SessionOptions.TempHealthDecayRate = 0.27;
 }
 
-function OnGameEvent_player_hurt_concise( params )
+function OnGameEvent_player_hurt( params )
 {
 	local player = GetPlayerFromUserID( params["userid"] );
-	if ( (!player) || (!player.IsSurvivor()) || (player.IsHangingFromLedge()) )
+	if ( !player || !player.IsSurvivor() || player.IsHangingFromLedge() )
 		return;
 
-	if ( NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 0 && player.GetHealth() < (player.GetMaxHealth() / 4) )
+	if ( NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 0 )
 	{
-		player.SetReviveCount( 0 );
-		NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
+		local health = player.GetHealth();
+		if ( health > 0 )
+		{
+			if ( !IsPlayerABot( player ) )
+			{
+				local scope = player.GetScriptScope();
+				if ( !scope.HeartbeatOn && health < player.GetMaxHealth() / 4 )
+				{
+					EmitSoundOnClient( "Player.Heartbeat", player );
+					scope.HeartbeatOn = true;
+				}
+			}
+			if ( health == 1 )
+			{
+				NetProps.SetPropInt( player, "m_bIsOnThirdStrike", 1 );
+				NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
+			}
+		}
 	}
 }
 
 function OnGameEvent_defibrillator_used( params )
 {
 	local player = GetPlayerFromUserID( params["subject"] );
-	if ( (!player) || (!player.IsSurvivor()) )
+	if ( !player )
 		return;
 
-	player.SetHealth( 24 );
-	player.SetHealthBuffer( 36 );
-	player.SetReviveCount( 0 );
+	player.SetHealth( 1 );
+	player.SetHealthBuffer( 99 );
+
+	if ( !IsPlayerABot( player ) )
+	{
+		EmitSoundOnClient( "Player.Heartbeat", player );
+		player.GetScriptScope().HeartbeatOn = true;
+	}
+	NetProps.SetPropInt( player, "m_bIsOnThirdStrike", 1 );
 	NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
+}
+
+function OnGameEvent_heal_success( params )
+{
+	local player = GetPlayerFromUserID( params["subject"] );
+	if ( !player )
+		return;
+
+	if ( !IsPlayerABot( player ) )
+	{
+		local scope = player.GetScriptScope();
+		if ( scope.HeartbeatOn && player.GetHealth() >= player.GetMaxHealth() / 4 )
+		{
+			StopSoundOn( "Player.Heartbeat", player );
+			scope.HeartbeatOn = false;
+		}
+	}
 }
 
 function CheckHealthAfterLedgeHang( userid )
 {
 	local player = GetPlayerFromUserID( userid );
-	if ( (!player) || (!player.IsSurvivor()) )
+	if ( !player )
 		return;
 
-	if ( player.GetHealth() < (player.GetMaxHealth() / 4) )
+	local health = player.GetHealth();
+
+	if ( !IsPlayerABot( player ) )
 	{
-		player.SetReviveCount( 0 );
+		local scope = player.GetScriptScope();
+		if ( !scope.HeartbeatOn && health < player.GetMaxHealth() / 4 )
+		{
+			EmitSoundOnClient( "Player.Heartbeat", player );
+			scope.HeartbeatOn = true;
+		}
+	}
+	if ( health == 1 )
+	{
+		NetProps.SetPropInt( player, "m_bIsOnThirdStrike", 1 );
 		NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
 	}
 }
@@ -102,20 +154,75 @@ function CheckHealthAfterLedgeHang( userid )
 function OnGameEvent_revive_success( params )
 {
 	local player = GetPlayerFromUserID( params["subject"] );
-	if ( (!params["ledge_hang"]) || (!player) || (!player.IsSurvivor()) )
+	if ( !params["ledge_hang"] || !player )
 		return;
 
 	if ( NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 0 )
-		EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.CheckHealthAfterLedgeHang(" + params["subject"] + ")", 0.1 );
+		EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.CheckHealthAfterLedgeHang(" + params["subject"] + ")" );
+}
+
+function OnGameEvent_player_spawn( params )
+{
+	local player = GetPlayerFromUserID( params["userid"] );
+	if ( !player || !player.IsSurvivor() )
+		return;
+
+	if ( !IsPlayerABot( player ) )
+	{
+		player.ValidateScriptScope();
+		local scope = player.GetScriptScope();
+		if ( !("HeartbeatOn" in scope) )
+			scope.HeartbeatOn <- false;
+	}
+}
+
+function OnGameEvent_player_death( params )
+{
+	if ( !("userid" in params) )
+		return;
+
+	local player = GetPlayerFromUserID( params["userid"] );
+	if ( !player || !player.IsSurvivor() )
+		return;
+
+	if ( !IsPlayerABot( player ) )
+	{
+		local scope = player.GetScriptScope();
+		if ( scope.HeartbeatOn )
+		{
+			StopSoundOn( "Player.Heartbeat", player );
+			scope.HeartbeatOn = false;
+		}
+	}
+}
+
+function OnGameEvent_player_bot_replace( params )
+{
+	local player = GetPlayerFromUserID( params["player"] );
+	if ( !player || !player.IsSurvivor() ) // in case an infected player uses jointeam 1
+		return;
+
+	local scope = player.GetScriptScope();
+	if ( scope.HeartbeatOn )
+	{
+		StopSoundOn( "Player.Heartbeat", player );
+		scope.HeartbeatOn = false;
+	}
 }
 
 function OnGameEvent_bot_player_replace( params )
 {
 	local player = GetPlayerFromUserID( params["player"] );
-	if ( (!player) || (NetProps.GetPropInt( player, "m_bIsOnThirdStrike" ) == 1) )
+	if ( !player )
 		return;
 
-	StopSoundOn( "Player.Heartbeat", player );
+	if ( !player.IsDead() ) // in case jointeam 2 or sb_takecontrol was used on a dead bot
+	{
+		if ( player.GetHealth() < player.GetMaxHealth() / 4 )
+			player.GetScriptScope().HeartbeatOn = true; // unreliable if sb_takecontrol was used
+		else
+			StopSoundOn( "Player.Heartbeat", player );
+	}
 }
 
 function OnGameEvent_player_complete_sacrifice( params )
@@ -138,8 +245,12 @@ if ( !Director.IsSessionStartMap() )
 
 		player.SetHealth( 24 );
 		player.SetHealthBuffer( 26 );
-		player.SetReviveCount( 0 );
-		NetProps.SetPropInt( player, "m_isGoingToDie", 1 );
+
+		if ( !IsPlayerABot( player ) )
+		{
+			EmitSoundOnClient( "Player.Heartbeat", player );
+			player.GetScriptScope().HeartbeatOn = true;
+		}
 	}
 
 	function PlayerSpawnAliveAfterTransition( userid )
@@ -148,16 +259,13 @@ if ( !Director.IsSessionStartMap() )
 		if ( !player )
 			return;
 
-		local maxHealth = player.GetMaxHealth();
 		local oldHealth = player.GetHealth();
-		local maxHeal = maxHealth / 2;
+		local maxHeal = player.GetMaxHealth() / 2;
 		local healAmount = 0;
 
 		if ( oldHealth < maxHeal )
-			healAmount = floor( ((maxHeal - oldHealth) * 0.8) + 0.5 );
-
-		if ( healAmount > 0 )
 		{
+			healAmount = floor( (maxHeal - oldHealth) * 0.8 + 0.5 );
 			player.SetHealth( oldHealth + healAmount );
 			local bufferHealth = player.GetHealthBuffer() - healAmount;
 			if ( bufferHealth < 0.0 )
@@ -171,12 +279,12 @@ if ( !Director.IsSessionStartMap() )
 	function OnGameEvent_player_transitioned( params )
 	{
 		local player = GetPlayerFromUserID( params["userid"] );
-		if ( (!player) || (!player.IsSurvivor()) )
+		if ( !player || !player.IsSurvivor() )
 			return;
 
 		if ( NetProps.GetPropInt( player, "m_lifeState" ) == 2 )
-			EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.PlayerSpawnDeadAfterTransition(" + params["userid"] + ")", 0.1 );
+			EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.PlayerSpawnDeadAfterTransition(" + params["userid"] + ")", 0.03 );
 		else
-			EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.PlayerSpawnAliveAfterTransition(" + params["userid"] + ")", 0.1 );
+			EntFire( "worldspawn", "RunScriptCode", "g_ModeScript.PlayerSpawnAliveAfterTransition(" + params["userid"] + ")" );
 	}
 }


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modified live game files first.

## What exactly is changed and why?

- B&W is now applied at 1 permanent HP (heartbeat sound still plays when below 25% health).
- Defibrillator now heals 1 permanent + 99 temporary HP (still B&W).
- Fixed medkit stopping heartbeat sound despite health being below 25% when using increased max health.
- Potentially fixed rare issue where effects and health were not updated after ledge hang and in start safe room, respectively.
- Fixed health effects not being applied to team 4 humans when hurt directly.

## Is there anything specific that needs review?

No.

## Does this address any open issues?

Resolves #268.