### PR TITLE
Fix inconsistent AK47 muzzleflash

### DIFF
--- a/root/scripts/weapon_rifle_ak47.txt
+++ b/root/scripts/weapon_rifle_ak47.txt
@@ -17,8 +17,8 @@ WeaponData
 	"ResponseRulesName"		"Rifle_AK47"
 
 	// particle muzzle flash effect to play when fired
-	"MuzzleFlashEffect_1stPerson"		"weapon_muzzle_flash_smg_FP"
-	"MuzzleFlashEffect_3rdPerson"		"weapon_muzzle_flash_smg"
+	"MuzzleFlashEffect_1stPerson"		"weapon_muzzle_flash_assaultrifle_FP"
+	"MuzzleFlashEffect_3rdPerson"		"weapon_muzzle_flash_assaultrifle"
 
 	// model for the shell casing to eject when we fire bullets
 	"EjectBrassEffect"		"weapon_shell_casing_rifle"

--- a/root/scripts/weapon_rifle_ak47.txt
+++ b/root/scripts/weapon_rifle_ak47.txt
@@ -1,0 +1,159 @@
+WeaponData
+{
+	// Terror-specific Data --------------------
+	"VerticalPunch"			"2"
+	"SpreadPerShot"			"1.6"   
+	"MaxSpread"			"35"
+	"SpreadDecay"			"7"		
+	"MinDuckingSpread"		"0.5"	
+	"MinStandingSpread"		"1" 	
+	"MinInAirSpread"		"3"
+	"MaxMovementSpread"		"6"
+	"AddonAttachment"		"primary"
+	"Team" 				"Survivor"
+
+	"Tier"				"2"		// valid entries are 0, 1, 2
+
+	"ResponseRulesName"		"Rifle_AK47"
+
+	// particle muzzle flash effect to play when fired
+	"MuzzleFlashEffect_1stPerson"		"weapon_muzzle_flash_smg_FP"
+	"MuzzleFlashEffect_3rdPerson"		"weapon_muzzle_flash_smg"
+
+	// model for the shell casing to eject when we fire bullets
+	"EjectBrassEffect"		"weapon_shell_casing_rifle"
+
+	// Used in the music system when this weapon fires
+	"MusicDynamicSpeed"		"0.35"
+
+	"DisplayName"				"#L4D_Weapon_Rifle_AK47"
+	"DisplayNameAllCaps"		"#L4D_Weapon_Rifle_AK47_CAPS"
+
+	"NewInL4D2"				"1"
+
+	// 360 Terror Data
+	"MaxAutoAimDeflection1"			"10.0"
+	"MaxAutoAimRange1"			"0"
+	//This value determins how "big" a target is for auto aim. If a target is 10.0 units big then it is considered 10.0*scale.  
+	//You can think about this value controlling a falloff value on distant targets, the smaller the value the harder it is to hit at a distance.
+	"WeaponAutoAimScale"			"1.0"
+	// End Terror-specific Data ----------------
+
+	"Rumble"			"4"
+
+	"MaxPlayerSpeed" 		"230" 
+	"WeaponType" 			"rifle"
+	"WeaponPrice" 			"3100"
+	"WeaponArmorRatio" 		"1.4"
+	"CrosshairMinDistance" 		"4"
+	"CrosshairDeltaDistance" 	"3"
+	"BuiltRightHanded" 		"1"
+	"PlayerAnimationExtension" 	"m4"
+
+	"CanEquipWithShield"		"0"
+
+
+	// Weapon characteristics:
+	"PenetrationNumLayers"		"2"
+	"PenetrationPower"			"50"
+	"PenetrationMaxDistance"	"0"	// none
+
+	"Damage"			"58"	//was 33
+	"Range"				"3000"
+	"RangeModifier"			"0.97"
+	"GainRange"			"1500"	// range at which to use a gain curve to fall off to zero
+	"Bullets"			"1"
+	"CycleTime"			"0.13"
+
+	"TimeToIdle"			"1.5"
+	"IdleInterval"			"60"
+	
+	// Weapon data is loaded by both the Game and Client DLLs.
+	"printname"			"Assault Rifle"
+
+	"playermodel"			"models/w_models/weapons/w_rifle_ak47.mdl"
+	
+	"viewmodel"			"models/v_models/v_rifle_AK47.mdl"
+	"CharacterViewmodelAddon"
+	{
+		"Coach"				"models/weapons/arms/v_arms_coach_new.mdl"
+		"Mechanic"			"models/weapons/arms/v_arms_mechanic_new.mdl"
+		"Producer"			"models/weapons/arms/v_arms_producer_new.mdl"
+		"Gambler"			"models/weapons/arms/v_arms_gambler_new.mdl"
+
+		"Manager"			"models/weapons/arms/v_arms_louis.mdl"
+		"Biker"				"models/weapons/arms/v_arms_francis.mdl"
+		"TeenGirl"			"models/weapons/arms/v_arms_zoey.mdl"
+		"NamVet"			"models/weapons/arms/v_arms_bill.mdl"
+	}
+
+	"anim_prefix"			"anim"
+	"bucket"			"0"
+	"bucket_position"		"0"
+
+	"clip_size"			"40"   //was 50
+	
+	"primary_ammo"			"AMMO_TYPE_ASSAULTRIFLE"
+	"secondary_ammo"		"None"
+
+	"weight"			"25"
+	"item_flags"			"0"
+
+	"LoadoutSlots"	"2"
+
+	// Sounds for the weapon. There is a max of 16 sounds per category (i.e. max 16 "single_shot" sounds)
+	SoundData
+	{
+		"single_shot"		"AK47.Fire"
+		"shoot_incendiary"	"AK47.FireIncendiary"
+	}
+
+	// Weapon Sprite data is loaded by the Client DLL.
+	TextureData
+	{
+		"weapon"
+		{
+				"file"		"vgui/hud/icon_rifle_ak47"
+				"x"		"0"
+				"width"		"256"
+				"height"	"64"	
+		}
+		"ammo"
+		{
+				"file"		"vgui/hud/iconsheet"
+				"x"			"384"
+				"y"			"448"
+				"width"		"64"
+				"height"	"64"
+		}
+		"crosshair"
+		{
+				"file"		"sprites/crosshairs"
+				"x"			"0"
+				"y"			"48"
+				"width"		"24"
+				"height"	"24"
+		}
+		"autoaim"
+		{
+				"file"		"sprites/crosshairs"
+				"x"			"0"
+				"y"			"48"
+				"width"		"24"
+				"height"	"24"
+		}
+	}
+	ModelBounds
+	{
+		Viewmodel
+		{
+			Mins	"-10 -2 -13"
+			Maxs	"30 10 0"
+		}
+		World
+		{
+			Mins	"-8 -9 -6"
+			Maxs	"29 9 8"
+		}
+	}
+}


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

For some unknown reason the AK47 uses `weapon_muzzle_flash_smg` instead of `weapon_muzzle_flash_assaultrifle` like every other rifle type weapon.

This can be adjusted for constancy via changing
```
	"MuzzleFlashEffect_1stPerson"		"weapon_muzzle_flash_smg_FP"
	"MuzzleFlashEffect_3rdPerson"		"weapon_muzzle_flash_smg"
```
to 
```
	"MuzzleFlashEffect_1stPerson"		"weapon_muzzle_flash_assaultrifle_FP"
	"MuzzleFlashEffect_3rdPerson"		"weapon_muzzle_flash_assaultrifle"
```
In `weapon_rifle_ak47.txt`

### Additional preview images showing the difference 
![image](https://github.com/Tsuey/L4D2-Community-Update/assets/19815283/5277a70a-1c6b-4e83-a3cb-f8c7852fff86)
![image](https://github.com/Tsuey/L4D2-Community-Update/assets/19815283/be302f5a-3f38-4e34-a765-c7c75b9fd8af)

## Is there anything specific that needs review? (Consider marking as a draft.)

No

## Does this address any open issues?

[__Issue 403: AK47 uses SMG muzzleflash__](https://github.com/Tsuey/L4D2-Community-Update/issues/403)