### PR TITLE
Fixed missing normal map on "Destruct_stonetiles1" Cold Stream material

### DIFF
--- a/root/materials/TextureHub/destruction/destruct_stonetiles1_spi.vmt
+++ b/root/materials/TextureHub/destruction/destruct_stonetiles1_spi.vmt
@@ -1,0 +1,7 @@
+lightmappedgeneric
+{
+$baseTexture "TextureHub/destruction/destruct_stonetiles1_spi"
+//$bumpmap "TextureHub/destruction/destruct_stonetiles1_norm_spi"
+$surfaceprop tile
+"%keywords" TextureHub
+}


### PR DESCRIPTION
## What exactly is changed and why?

A material had a missing bump map. It tends to show up in custom campaigns now and then, likely because some mappers don't or can't run the game at full video settings. This change removes the bump map command from the material.

Before:
![20230801201942_1](https://github.com/Tsuey/L4D2-Community-Update/assets/49519725/fa1ea46d-e0b9-4ff6-8c3a-a329556ae951)

After:
![20230801201920_2](https://github.com/Tsuey/L4D2-Community-Update/assets/49519725/d39abd62-2821-432d-90fb-a4b508effed7)

The campaign used to obtain the screenshots is "Rescue Dawn", if you wish to observe the changes yourself - https://steamcommunity.com/sharedfiles/filedetails/?id=3010073358