### PR TITLE
Rainy Roadcrew Phongboost

### DIFF
--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
 $detailscale 2
 $phongtint "[1 1 1]"

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
 $detailscale 2
 $EYEGLOW 1

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
 $detailscale 2
 $EYEGLOW 1

--- a/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_roadcrew_rain_wounded_burning.vmt
@@ -5,6 +5,7 @@ insert
 {
 $basetexture "models/infected/common/l4d2/cim_roadcrew_rain"
 $detail "models/infected/common/l4d2/detail/ci_detail_mud"
+$phongboost 2
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_roadcrew"
 $detailscale 2
 $EYEGLOW 1


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modifiied live game files first.

## What exactly is changed and why?

Restores the phongboost of rainy roadcrew zombies. The phongboost helps rainy infected look wet and reflective.
The phongboost is present in the live game, but not on the current github version.

## Is there anything specific that needs review? (Consider marking as a draft.)

No

## Does this address any open issues?

No