### PR TITLE
Riot infected detail

### DIFF
--- a/root/materials/models/infected/common/l4d1/cim_riot_l4d1_burning.vmt
+++ b/root/materials/models/infected/common/l4d1/cim_riot_l4d1_burning.vmt
@@ -1,0 +1,18 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d1/cim_riot_l4d1"
+$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$GRADIENTTEXTURE "models/infected/common/l4d1/ci_gradient_palette_riot_l4d1"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$BURNING 1
+$EYEGLOWCOLOR "[2 1 1]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d1/cim_riot_l4d1_burning.vmt
+++ b/root/materials/models/infected/common/l4d1/cim_riot_l4d1_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d1/cim_riot_l4d1"
-$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$detail "models/infected/common/l4d2/detail/ci_detail_dirt"
 $GRADIENTTEXTURE "models/infected/common/l4d1/ci_gradient_palette_riot_l4d1"
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"
@@ -12,7 +12,7 @@ $phongboost 1
 $DEFAULTPHONGEXPONENT 15
 $EYEGLOW 1
 $BURNING 1
-$EYEGLOWCOLOR "[2 1 1]"
+$EYEGLOWCOLOR "[2 2 2]"
 $EYEGLOWFLASHLIGHTBOOST 10
 }
 }

--- a/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded.vmt
+++ b/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded.vmt
@@ -1,0 +1,18 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d1/cim_riot_l4d1"
+$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$GRADIENTTEXTURE "models/infected/common/l4d1/ci_gradient_palette_riot_l4d1"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$WOUNDED 1
+$EYEGLOWCOLOR "[2 1 1]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded.vmt
+++ b/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d1/cim_riot_l4d1"
-$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$detail "models/infected/common/l4d2/detail/ci_detail_dirt"
 $GRADIENTTEXTURE "models/infected/common/l4d1/ci_gradient_palette_riot_l4d1"
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"
@@ -12,7 +12,7 @@ $phongboost 1
 $DEFAULTPHONGEXPONENT 15
 $EYEGLOW 1
 $WOUNDED 1
-$EYEGLOWCOLOR "[2 1 1]"
+$EYEGLOWCOLOR "[2 2 2]"
 $EYEGLOWFLASHLIGHTBOOST 10
 }
 }

--- a/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d1/cim_riot_l4d1"
-$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$detail "models/infected/common/l4d2/detail/ci_detail_dirt"
 $GRADIENTTEXTURE "models/infected/common/l4d1/ci_gradient_palette_riot_l4d1"
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"
@@ -13,7 +13,7 @@ $DEFAULTPHONGEXPONENT 15
 $EYEGLOW 1
 $WOUNDED 1
 $BURNING 1
-$EYEGLOWCOLOR "[2 1 1]"
+$EYEGLOWCOLOR "[2 2 2]"
 $EYEGLOWFLASHLIGHTBOOST 10
 }
 }

--- a/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d1/cim_riot_l4d1_wounded_burning.vmt
@@ -1,0 +1,19 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d1/cim_riot_l4d1"
+$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$GRADIENTTEXTURE "models/infected/common/l4d1/ci_gradient_palette_riot_l4d1"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$WOUNDED 1
+$BURNING 1
+$EYEGLOWCOLOR "[2 1 1]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_riot_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_riot_burning.vmt
@@ -1,0 +1,18 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_riot"
+$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_riot"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$BURNING 1
+$EYEGLOWCOLOR "[2 2 2]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_riot_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_riot_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_riot"
-$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$detail "models/infected/common/l4d2/detail/ci_detail_dirt"
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_riot"
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"

--- a/root/materials/models/infected/common/l4d2/cim_riot_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_riot_wounded.vmt
@@ -1,0 +1,18 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_riot"
+$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_riot"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$WOUNDED 1
+$EYEGLOWCOLOR "[2 2 2]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_riot_wounded.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_riot_wounded.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_riot"
-$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$detail "models/infected/common/l4d2/detail/ci_detail_dirt"
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_riot"
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"

--- a/root/materials/models/infected/common/l4d2/cim_riot_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_riot_wounded_burning.vmt
@@ -1,0 +1,19 @@
+patch
+{
+include "materials/models/infected/common/l4d2/ci_body_include.vmt"
+insert
+{
+$basetexture "models/infected/common/l4d2/cim_riot"
+$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_riot"
+$phongtint "[1 1 1]"
+$phongfresnelranges "[1 1 1]"
+$phongboost 1
+$DEFAULTPHONGEXPONENT 15
+$EYEGLOW 1
+$WOUNDED 1
+$BURNING 1
+$EYEGLOWCOLOR "[2 2 2]"
+$EYEGLOWFLASHLIGHTBOOST 10
+}
+}

--- a/root/materials/models/infected/common/l4d2/cim_riot_wounded_burning.vmt
+++ b/root/materials/models/infected/common/l4d2/cim_riot_wounded_burning.vmt
@@ -4,7 +4,7 @@ include "materials/models/infected/common/l4d2/ci_body_include.vmt"
 insert
 {
 $basetexture "models/infected/common/l4d2/cim_riot"
-$detail "models/infected/common/l4d2/detail/ci_detail_crud"
+$detail "models/infected/common/l4d2/detail/ci_detail_dirt"
 $GRADIENTTEXTURE "models/infected/common/l4d2/ci_gradient_palette_riot"
 $phongtint "[1 1 1]"
 $phongfresnelranges "[1 1 1]"


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit unmodified live game files first.

## What exactly is changed and why?

Fixes the vmts of wounded/burning riot infected changing the appearance of the model after death.
Also makes a slight change the eyeglow of l4d1 wounded riot infected to be the same as wounded l4d2 riot infected.

## Is there anything specific that needs review? (Consider marking as a draft.)

No

## Does this address any open issues?

Yes #425 