### PR TITLE
Francis' Grenade Launcher Criteria Fix

### DIFF
--- a/root/scripts/talker/biker.txt
+++ b/root/scripts/talker/biker.txt
@@ -9309,7 +9309,7 @@ Rule SurvivorSpottedM60AutoBiker
 
 Rule SurvivorSpottedGrenadeLauncherBiker
 {
-	criteria ConceptPlayerSpotWeapon IsNotCoughing IsProducer IsTalk IsTalkBiker IsNotSmartLookAuto Isgrenade_launcher IsWorldTalkBiker _auto_NotSpottedVehicle
+	criteria ConceptPlayerSpotWeapon IsNotCoughing IsBiker IsTalk IsTalkBiker IsNotSmartLookAuto Isgrenade_launcher IsWorldTalkBiker _auto_NotSpottedVehicle
 	ApplyContext "SaidSpotgrenade_launcher:1:5,SaidSpot:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedChainsawBiker
@@ -9317,7 +9317,7 @@ Rule SurvivorSpottedGrenadeLauncherBiker
 
 Rule SurvivorSpottedGrenadeLauncherAutoBiker
 {
-	criteria ConceptPlayerSpotWeapon IsNotCoughing IsProducer IsTalk IsTalkBiker IsSmartLookAuto IsNotInSafeSpot IsNotAlone IsNotSaidSpotgrenade_launcher IsNotSaidSpot Isgrenade_launcher IsWorldTalkBiker IsNotSpeakingWeight0 _auto_NotSpottedVehicle
+	criteria ConceptPlayerSpotWeapon IsNotCoughing IsBiker IsTalk IsTalkBiker IsSmartLookAuto IsNotInSafeSpot IsNotAlone IsNotSaidSpotgrenade_launcher IsNotSaidSpot Isgrenade_launcher IsWorldTalkBiker IsNotSpeakingWeight0 _auto_NotSpottedVehicle
 	ApplyContext "SaidSpotgrenade_launcher:1:5,SaidSpot:1:20"
 	applycontexttoworld
 	Response SurvivorSpottedChainsawBiker


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modified live game files first.

## What exactly is changed and why?

Changes the `IsProducer` criteria in Francis' gl spotting rules to `IsBiker` to prevent Rochelle from using Francis' lines (ensuring that Francis properly remarks when he sees a grenade launcher instead in the process)

## Is there anything specific that needs review?

Make sure Rochelle doesn't start mimicking Francis whenever she sees a grenade launcher...

## Does this address any open issues?

Fixes #483 