### PR TITLE
Improve game mode selectivity of VScript God spots

### DIFF
--- a/root/scripts/vscripts/community/maps/c10m2_drainage.nut
+++ b/root/scripts/vscripts/community/maps/c10m2_drainage.nut
@@ -104,8 +104,7 @@ function DoRoundFixes()
 		make_ladder( "_ladder_versussurvivalfence2_cloned_tunnelmid", "-9478.5 -7280 -384", "155 0 -410" );
 		make_ladder( "_ladder_versussurvivalfence3_cloned_tunnelmid", "-9478.5 -7280 -384", "155 -45 -410" );
 	}
-
-	if ( g_MutaMode == "mutation19" )
+	else if ( g_MutaMode == "mutation19" )
 	{
 		// Excessively problematic map, most specifically the end area, so just
 		// delete all of these -- Tanks can get out of the map and venture to

--- a/root/scripts/vscripts/community/maps/c10m4_mainstreet.nut
+++ b/root/scripts/vscripts/community/maps/c10m4_mainstreet.nut
@@ -49,7 +49,7 @@ function DoRoundFixes()
 		make_clip( "_cliprework_eventskip3", "Survivors", 1, "-156 -1 0", "141 1 1588", "372 -2717 140" );
 		make_clip( "_cliprework_eventskip4", "Survivors", 1, "-26 -59 0", "-24 41 1588", "242 -2757 140" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 
@@ -172,8 +172,7 @@ function DoRoundFixes()
 		make_clip( "_tankstuck_endbarricade", "SI Players", 1, "-400 -900 0", "400 900 1700", "3822 -3970 0" );
 		make_clip( "_tankstuck_excesscorner", "SI Players", 1, "-200 -100 0", "200 100 1700", "-2520 -5048 -64" );
 	}
-
-	if ( g_MutaMode == "mutation19" )
+	else if ( g_MutaMode == "mutation19" )
 	{
 		// Tons of possibilities to spawn behind the long row of houses
 		// so just block them all off, tons of NODRAW and hostile clips.

--- a/root/scripts/vscripts/community/maps/c10m5_houseboat.nut
+++ b/root/scripts/vscripts/community/maps/c10m5_houseboat.nut
@@ -76,7 +76,7 @@ function DoRoundFixes()
 
 	EntFire( "trigger_finale", "AddOutput", "UseStart worldspawn:CallScriptFunction:c10m5_rockslide:0:-1" );
 
-	if ( g_BaseMode == "coop" || g_BaseMode == "realism" )
+	if ( g_MutaMode == "coop" || g_MutaMode == "realism" )
 	{
 		// Get nav tiles by position because IDS can change if edited later on
 		local navMain = NavMesh.GetNearestNavArea(Vector(1612.500000, -3662.500000, 26.890617), 16, true, true)

--- a/root/scripts/vscripts/community/maps/c10m5_houseboat.nut
+++ b/root/scripts/vscripts/community/maps/c10m5_houseboat.nut
@@ -89,7 +89,7 @@ function DoRoundFixes()
 		navConnection3.Disconnect(navMain);
 		navConnection4.Disconnect(navMain);
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 
@@ -97,7 +97,7 @@ function DoRoundFixes()
 
 		make_clip(	"_indoor_roof",			"Survivors",	1,	"-60 -84 -28",		"60 84 28",		"2244 4076 100" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c11m2_offices.nut
+++ b/root/scripts/vscripts/community/maps/c11m2_offices.nut
@@ -40,7 +40,7 @@ function DoRoundFixes()
 		make_trighurt( "_finalstreet_trighurtc", "Survivor", "-781 -361 0", "359 599 32", "9101 4969 196" );
 		DoEntFire( "!self", "AddOutput", "OnTrigger " + g_UpdateName + "_finalstreet_trighurt*:Kill::0:-1", 0.0, null, Entities.FindByClassnameNearest( "trigger_once", Vector( 8616, 4320, 140 ), 1 ) );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 
@@ -87,8 +87,7 @@ function DoRoundFixes()
 
 		kill_funcinfclip( 1043.94 );	// Final street left barricade
 	}
-
-	if ( g_MutaMode == "mutation19" )
+	else if ( g_MutaMode == "mutation19" )
 	{
 		// Block an excess nav area that's quite far behind a fence.
 

--- a/root/scripts/vscripts/community/maps/c11m3_garage.nut
+++ b/root/scripts/vscripts/community/maps/c11m3_garage.nut
@@ -43,11 +43,11 @@ function DoRoundFixes()
 	{
 		make_clip(	"_cliprework_construction05",	"Survivors",	1,	"-8 -472 0",		"1337 488 888",		"-5384 -1528 1000" );
 	}
-	if ( g_BaseMode == "coop" || g_BaseMode == "realism")
+	if ( g_BaseMode == "coop" || g_BaseMode == "realism" )
 	{
 		EntFire( "construction_clip", "Kill", "", 1 );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 

--- a/root/scripts/vscripts/community/maps/c11m4_terminal.nut
+++ b/root/scripts/vscripts/community/maps/c11m4_terminal.nut
@@ -61,7 +61,7 @@ function DoRoundFixes()
 
 		patch_spawninfront( "2552 4080 152", "0 -16 0", "614 16 244" );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 

--- a/root/scripts/vscripts/community/maps/c11m5_runway.nut
+++ b/root/scripts/vscripts/community/maps/c11m5_runway.nut
@@ -19,6 +19,7 @@ function DoRoundFixes()
 	{
 		make_clip( "_nav_skybridge", "Survivors", 1, "-643 -102 0", "878 106 1427", "-6035 8761 32", "0 45 0" );
 	}
+
 	if ( HasPlayerControlledZombies() )
 	{
 		EntFire( "worldspawn", "RunScriptFile", "community/c11m5_versus_planecrash" );

--- a/root/scripts/vscripts/community/maps/c12m3_bridge.nut
+++ b/root/scripts/vscripts/community/maps/c12m3_bridge.nut
@@ -35,7 +35,7 @@ function DoRoundFixes()
 
 		patch_spawninfront( "7136 -11876 394", "0 -164 -24", "800 4 134" );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 
@@ -43,7 +43,7 @@ function DoRoundFixes()
 
 		patch_spawninfront( "7136 -11876 394", "0 -164 -24", "800 4 134" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c12m4_barn.nut
+++ b/root/scripts/vscripts/community/maps/c12m4_barn.nut
@@ -41,7 +41,7 @@ function DoRoundFixes()
 
 		EntFire( g_UpdateName + "_eventskip_commonhop*", "Kill", null, 4 );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 

--- a/root/scripts/vscripts/community/maps/c12m5_cornfield.nut
+++ b/root/scripts/vscripts/community/maps/c12m5_cornfield.nut
@@ -36,6 +36,7 @@ function DoRoundFixes()
 		make_clip( "_cooponly_idle_warp", "Survivors", 1, "-81 -37 0", "55 35 1102", "8849 3493 760" );
 		make_clip( "_nav_and_stuckwarp", "Everyone", 1, "-45 -2 -62", "163 6 58", "6485 1090 308" );
 	}
+
 	if ( HasPlayerControlledZombies() )
 	{
 		kill_funcinfclip( 3833.37 );		// Delete clip blocking access to vast start perimeter and one-way drop

--- a/root/scripts/vscripts/community/maps/c13m3_memorialbridge.nut
+++ b/root/scripts/vscripts/community/maps/c13m3_memorialbridge.nut
@@ -52,7 +52,7 @@ function DoRoundFixes()
 
 		patch_ladder( "-410.09 -4121.79 1386", "15 15 10" );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 

--- a/root/scripts/vscripts/community/maps/c14m1_junkyard.nut
+++ b/root/scripts/vscripts/community/maps/c14m1_junkyard.nut
@@ -84,7 +84,7 @@ function DoRoundFixes()
 			}
 		}
 	}
-	if ( g_BaseMode == "versus" )
+	else
 	{
 		EntFire( "car_alarm_prop", "Kill", null, 0 );
 		EntFire( "car_alarm_event", "Kill", null, 0 );

--- a/root/scripts/vscripts/community/maps/c1m1_hotel.nut
+++ b/root/scripts/vscripts/community/maps/c1m1_hotel.nut
@@ -20,7 +20,7 @@ function DoRoundFixes()
 		make_clip( "_commentary_lower_windows_e", "Everyone", 1, "-8 -56 -570", "4 8 8", "1654 6584 2473" );
 		make_clip( "_commentary_lower_windows_f", "Everyone", 1, "-8 -56 -570", "4 8 8", "1654 6456 2473" );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 

--- a/root/scripts/vscripts/community/maps/c2m1_highway.nut
+++ b/root/scripts/vscripts/community/maps/c2m1_highway.nut
@@ -71,7 +71,7 @@ function DoRoundFixes()
 		make_clip( "_tank_busright", "Survivors", 1, "-284 -48 -200", "284 48 200", "1688 7008 -344", "0 22 0" );
 		make_clip( "_tank_fence", "Survivors", 1, "-780 -14 -130", "780 14 156", "2588 7168 -412" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 
@@ -82,7 +82,7 @@ function DoRoundFixes()
 		make_clip( "_survival_boostshrub", "Survivors", 1, "-24 -208 0", "27 280 112", "3079 6479 -343" );
 		make_clip( "_survival_fence_extend", "Survivors", 1, "0 -234 0", "77 0 360", "2042 3837 -640" );
 	}
-	if ( g_BaseMode == "scavenge" )
+	else if ( g_BaseMode == "scavenge" )
 	{
 		devchap( "BASE SCAVENGE" );
 

--- a/root/scripts/vscripts/community/maps/c2m4_barns.nut
+++ b/root/scripts/vscripts/community/maps/c2m4_barns.nut
@@ -59,7 +59,7 @@ function DoRoundFixes()
 
 		EntFire( g_UpdateName + "_outhouse_saferoof", "Kill" );
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 
@@ -71,7 +71,7 @@ function DoRoundFixes()
 		make_clip( "_commentary_shortcut_generator_a", "Survivors", 1, "-5 -5 -98", "5 5 98", "-1721 373 -94" );
 		make_clip( "_commentary_shortcut_generator_b", "Survivors", 1, "-28 -20 -504", "28 20 504", "-1718.5 376 520" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c2m5_concert.nut
+++ b/root/scripts/vscripts/community/maps/c2m5_concert.nut
@@ -90,10 +90,13 @@ function DoRoundFixes()
 		make_prop( "dynamic", "_helistuck_caseunique", "models/props_fairgrounds/bass_case.mdl", "-3466 2899 -106", "-15 1 89.73", "shadow_yes" );
 		make_prop( "dynamic", "_helistuck_casecaster", "models/props_fairgrounds/anvil_case_casters_64.mdl", "-3488 2870 -128", "0 180 0", "shadow_yes" );
 
-		// Get nav tiles by position because IDS can change if edited later on
-		local navConnection = NavMesh.GetNearestNavArea(Vector(-3400.000000, 3400.000000, -165.604355), 16, true, true);
-		local navMain = NavMesh.GetNearestNavArea(Vector(-3396.963867, 3449.818848, -112.538177), 16, true, true);
-		navConnection.Disconnect(navMain);
+		if ( g_MutaMode == "coop" || g_MutaMode == "realism" )
+		{
+			// Get nav tiles by position because IDS can change if edited later on
+			local navConnection = NavMesh.GetNearestNavArea(Vector(-3400.000000, 3400.000000, -165.604355), 16, true, true);
+			local navMain = NavMesh.GetNearestNavArea(Vector(-3396.963867, 3449.818848, -112.538177), 16, true, true);
+			navConnection.Disconnect(navMain);
+		}
 	}
 	else if ( g_BaseMode == "versus" )
 	{

--- a/root/scripts/vscripts/community/maps/c2m5_concert.nut
+++ b/root/scripts/vscripts/community/maps/c2m5_concert.nut
@@ -89,13 +89,13 @@ function DoRoundFixes()
 
 		make_prop( "dynamic", "_helistuck_caseunique", "models/props_fairgrounds/bass_case.mdl", "-3466 2899 -106", "-15 1 89.73", "shadow_yes" );
 		make_prop( "dynamic", "_helistuck_casecaster", "models/props_fairgrounds/anvil_case_casters_64.mdl", "-3488 2870 -128", "0 180 0", "shadow_yes" );
-		
+
 		// Get nav tiles by position because IDS can change if edited later on
 		local navConnection = NavMesh.GetNearestNavArea(Vector(-3400.000000, 3400.000000, -165.604355), 16, true, true);
 		local navMain = NavMesh.GetNearestNavArea(Vector(-3396.963867, 3449.818848, -112.538177), 16, true, true);
 		navConnection.Disconnect(navMain);
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 

--- a/root/scripts/vscripts/community/maps/c3m1_plankcountry.nut
+++ b/root/scripts/vscripts/community/maps/c3m1_plankcountry.nut
@@ -79,7 +79,7 @@ function DoRoundFixes()
 
 		make_clip(	"_cliprework_jonesroof",	"Survivors",	1,	"-276 -296 -396",	"276 296 396",		"-8304 7216 628" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c3m4_plantation.nut
+++ b/root/scripts/vscripts/community/maps/c3m4_plantation.nut
@@ -35,7 +35,7 @@ function DoRoundFixes()
 		navConnection1.Disconnect(navMain);
 		navConnection2.Disconnect(navMain);
 	}
-	if ( g_BaseMode == "versus" )
+	else if ( g_BaseMode == "versus" )
 	{
 		devchap( "BASE VERSUS" );
 
@@ -43,7 +43,7 @@ function DoRoundFixes()
 
 		make_clip( "_commentary_shortcut_startfence", "Survivors", 1, "-8 -272 -80", "8 280 80", "-2380 -1616 78.2673" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c3m4_plantation.nut
+++ b/root/scripts/vscripts/community/maps/c3m4_plantation.nut
@@ -26,7 +26,7 @@ function DoRoundFixes()
 		make_clip( "_stuckwarp_understairs", "Everyone", 1, "4 -55 -25", "39 57 21", "2816 119 162" );
 		make_clip( "_booster_scaffoldpins", "Survivors", 1, "-199 -1 0", "146 9 909", "527 177 243" );
 	}
-	if ( g_BaseMode == "coop" || g_BaseMode == "realism" )
+	if ( g_MutaMode == "coop" || g_MutaMode == "realism" )
 	{
 		// Get nav tiles by position because IDS can change if edited later on
 		local navMain = NavMesh.GetNearestNavArea(Vector(2377.853516, 161.838699, 194.000000), 16, true, true);

--- a/root/scripts/vscripts/community/maps/c4m1_milltown_a.nut
+++ b/root/scripts/vscripts/community/maps/c4m1_milltown_a.nut
@@ -73,7 +73,7 @@ function DoRoundFixes()
 
 		make_clip( "_treehouse_whitefence", "Survivors", 1, "-17 -80 0", "17 77 1125", "1767 2219 267" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c4m2_sugarmill_a.nut
+++ b/root/scripts/vscripts/community/maps/c4m2_sugarmill_a.nut
@@ -94,7 +94,7 @@ function DoRoundFixes()
 		make_clip( "_commentary_factoryhopup_a", "Survivors", 1, "-70 -11 -8", "38 11 28", "1214 -4856 168" );
 		make_clip( "_commentary_factoryhopup_b", "Survivors", 1, "-48 -11 -8", "8 11 88", "1136 -4856 108" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c4m5_milltown_escape.nut
+++ b/root/scripts/vscripts/community/maps/c4m5_milltown_escape.nut
@@ -50,6 +50,7 @@ function DoRoundFixes()
 		local navConnection = NavMesh.GetNearestNavArea(Vector(-7145.000000, 7415.000000, 116.481155), 16, true, true);
 		navConnection.Disconnect(navMain);
 	}
+
 	if ( HasPlayerControlledZombies() )
 	{
 		make_brush( "_losfix_burger_gen",	"-24 -1 -8",	"24 1 8",	"-5448 6765 107" );

--- a/root/scripts/vscripts/community/maps/c4m5_milltown_escape.nut
+++ b/root/scripts/vscripts/community/maps/c4m5_milltown_escape.nut
@@ -43,7 +43,7 @@ function DoRoundFixes()
 	make_clip( "_commentary_booster_burgertree_e", "Survivors", 1, "-178 -136 -608", "178 136 608", "-5397 7956 928" );
 	make_clip( "_commentary_booster_burgertree_f", "Survivors", 1, "-178 -134 -628", "178 134 628", "-6806 7205 908" );
 
-	if ( g_BaseMode == "coop" || g_BaseMode == "realism" )
+	if ( g_MutaMode == "coop" || g_MutaMode == "realism" )
 	{
 		// Get nav tiles by position because IDS can change if edited later on
 		local navMain = NavMesh.GetNearestNavArea(Vector(-7188.924805, 7411.930664, 85.820847), 16, true, true);

--- a/root/scripts/vscripts/community/maps/c5m1_waterfront.nut
+++ b/root/scripts/vscripts/community/maps/c5m1_waterfront.nut
@@ -38,7 +38,7 @@ function DoRoundFixes()
 	make_clip( "_commentary_clipgap_endfence", "Survivors", 1, "-176 -32 -256", "176 32 256", "-4079 -1120 -120" );
 	make_prop( "dynamic", "_propladder_plankb", "models/props_swamp/plank001b_192.mdl", "-2176 -2538 -320", "0 0 35" );
 
-	if ( g_BaseMode != "coop" && g_BaseMode != "realism")
+	if ( g_BaseMode != "coop" && g_BaseMode != "realism" )
 	{
 		make_clip( "_ledgehang_startfenceleft", "Survivors", 1, "-16 -48 0", "10 48 379", "589 -142 -251", "0 29 0" );
 		make_clip( "_ledgehang_startfenceright", "Survivors", 1, "-8 -24 0", "8 24 360", "599 45 -232", "0 -15 0" );

--- a/root/scripts/vscripts/community/maps/c5m2_park.nut
+++ b/root/scripts/vscripts/community/maps/c5m2_park.nut
@@ -33,7 +33,7 @@ function DoRoundFixes()
 	make_clip( "_cliprework_missingno", "Survivors", 1, "-164 -272 0", "172 240 1626", "-10092 -5520 48" );
 	make_clip( "_commentary_fencegenerator", "Survivors", 1, "-8 -44 -8", "56 8 1672", "-8371 -3338 -8" );
 	make_clip( "_commentary_electricalbox", "Survivors", 1, "-4 -8 -8", "6 74 1800", "-7036 -5098 -239" );
-	
+
 	make_clip( "_commentary_shortcut_tent", "Survivors", 1, "-65 -65 -20", "65 65 1790", "-6853 -5598 -135.75" );
 
 	if ( g_BaseMode != "coop" && g_BaseMode != "realism" )
@@ -49,7 +49,7 @@ function DoRoundFixes()
 
 		make_clip(	"_nav_eventsign",		"Survivors",	1,	"-4 -10 -908",		"4 10 908",		"-8552 -6310 756" );
 	}
-	if ( g_BaseMode == "scavenge" )
+	else if ( g_BaseMode == "scavenge" )
 	{
 		devchap( "BASE SCAVENGE" );
 

--- a/root/scripts/vscripts/community/maps/c5m3_cemetery.nut
+++ b/root/scripts/vscripts/community/maps/c5m3_cemetery.nut
@@ -33,7 +33,7 @@ function DoRoundFixes()
 	make_clip( "_commentary_oob_bridgeexplosion", "Everyone", 1, "-1338 -1128 -8", "8 8 857", "6489 -5161 103" );
 	make_clip( "_commentary_clipgap_bridge", "Survivors", 1, "-512 -8 -8", "8 8 735", "6969 -3864 225" );
 
-	if ( g_BaseMode != "coop" && g_BaseMode != "realism")
+	if ( g_BaseMode != "coop" && g_BaseMode != "realism" )
 	{
 		make_clip(	"_stuckwarp_wrongwaya",		"SI Players",	1,	"-82.5 -201 -111",	"82.5 201 111",		"6275 9035 242" );
 		make_clip(	"_stuckwarp_wrongwayb",		"SI Players",	1,	"-21.5 -276 -111",	"21.5 276 111",		"6336 8960 242" );

--- a/root/scripts/vscripts/community/maps/c5m5_bridge.nut
+++ b/root/scripts/vscripts/community/maps/c5m5_bridge.nut
@@ -66,7 +66,7 @@ function DoRoundFixes()
 		make_clip( "_solidify_alt_stuckwarp3", "Survivors", 1, "-86 -10 -37", "15 11 32", "7145 6034 729" );
 		make_clip( "_solidify_alt_stuckwarp4", "Survivors", 1, "-86 -10 -37", "15 11 32", "7145 6617 729" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c6m1_riverbank.nut
+++ b/root/scripts/vscripts/community/maps/c6m1_riverbank.nut
@@ -13,7 +13,6 @@ PrecacheModel( "models/props_misc/wrongway_sign01_optimized.mdl" );
 
 function DoRoundFixes()
 {
-	
 	make_clip(	"_permstuck_tarptree",		"Everyone",	1,	"-17 -69 -17",		"17 17 17",		"1166 3794 191" );
 	make_clip(	"_commonhop_windowsill",	"Survivors",	1,	"-6 -216 0",		"6 216 800",		"539 2861 237" );
 	make_clip(	"_curvejump_pixelperfect",	"Survivors",	1,	"-24 -64 -128",		"24 64 128",		"4784 3785 83" );
@@ -56,7 +55,7 @@ function DoRoundFixes()
 	make_prop( "dynamic", "_cosmetic_right_plywood", "models/props_highway/plywood_02.mdl", "1450 1615 621", "-3 0 90", "shadow_no", "solid_no" );
 	make_clip( "_cosmetic_right_collision", "SI Players and AI", 1, "-17 -18 -30", "73 14 6", "1400 1637 542" );
 
-	if ( g_BaseMode != "coop" && g_BaseMode != "realism")
+	if ( g_BaseMode != "coop" && g_BaseMode != "realism" )
 	{
 		make_clip(	"_ghostgrief_tarpledge",	"Survivors",	1,	"-4 -313 -145",		"4 466 1337",		"1148 4257 96" );
 		make_clip( "_cliprework_bridgeroof", "Survivors", 1, "-218 -166 -4", "298 186 8", "927 4579 302" );

--- a/root/scripts/vscripts/community/maps/c6m2_bedlam.nut
+++ b/root/scripts/vscripts/community/maps/c6m2_bedlam.nut
@@ -6,7 +6,7 @@ PrecacheModel( "models/props_urban/gas_meter.mdl" );
 PrecacheModel( "models/props_rooftop/vent_large1.mdl" );
 
 function DoRoundFixes()
-{	
+{
 	make_clip( "_booster_dualwindows", "Survivors", 1, "-10 -168 -1", "10 140 89", "1953 561 178", "0 7 0" );
 	make_clip( "_frontloader_smoother", "Everyone", 1, "-14 -53 0", "27 53 32", "836 1612 -148" );
 	make_clip( "_ghostgrief_noio_gate1", "Everyone", 1, "-3 -39 0", "3 39 32", "2547 5704 -950" );
@@ -56,7 +56,7 @@ function DoRoundFixes()
 
 		EntFire( "button_minifinale", "AddOutput", "OnPressed " + g_UpdateName + "_commentary_minifinale_clip:Kill::0:-1" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c7m1_docks.nut
+++ b/root/scripts/vscripts/community/maps/c7m1_docks.nut
@@ -18,7 +18,7 @@ function DoRoundFixes()
 		make_clip( "_clipextend_arena_tree", "Survivors", 1, "-158 -137 0", "152 165 284", "9054 49 740" );
 		make_clip( "_booster_lonerpipe", "Survivors", 1, "-13 -12 0", "14 10 475", "9236 750 550" );
 	}
-	if ( g_BaseMode == "coop" || g_BaseMode == "realism" )
+	else
 	{
 		devchap( "BASE COOP" );
 

--- a/root/scripts/vscripts/community/maps/c7m2_barge.nut
+++ b/root/scripts/vscripts/community/maps/c7m2_barge.nut
@@ -23,7 +23,7 @@ function DoRoundFixes()
 	{
 		make_clip( "_stuckwarp_railwayoverpass", "Everyone", 1, "-30 -152 -45", "26 210 58", "2726 2775 374" );
 	}
-	if ( g_BaseMode == "scavenge" )
+	else if ( g_BaseMode == "scavenge" )
 	{
 		devchap( "BASE SCAVENGE" );
 

--- a/root/scripts/vscripts/community/maps/c8m2_subway.nut
+++ b/root/scripts/vscripts/community/maps/c8m2_subway.nut
@@ -36,7 +36,7 @@ function DoRoundFixes()
 	make_clip( "_ladderqol_orangebags", "SI Players and AI", 1, "-29 -23 27", "24 32 32", "10660 5215 16", "-45 0 0" );
 	make_clip( "_genroomrail_smoother1", "Everyone", 1, "-1 -33 0", "0 34 40", "7285 3633 248" );
 	make_clip( "_genroomrail_smoother2", "Everyone", 1, "-1 -65 0", "0 66 40", "7285 2878 248" );
-	
+
 	local rail01_model = "models/props_unique/handrail_subway01.mdl";
 	local rail02_model = "models/props_unique/handrail_subway02.mdl";
 	local rail_name = "_invisible_railing";
@@ -72,7 +72,7 @@ function DoRoundFixes()
 		make_clip( "_subwaymount_in", "Survivors", 1, "-49 -248 0", "63 247 58", "6337 3137 -154", "0 41 0" );
 		make_clip( "_subwaymount_out", "Survivors", 1, "-49 -248 0", "63 247 58", "6769 2895 -154", "0 79 0" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 
@@ -144,8 +144,7 @@ function DoRoundFixes()
 
 		make_prop( "dynamic", "_cosmetic_oobstep", "models/props/cs_office/vending_machine.mdl", "7366 3801 270", "90 0 0", "shadow_no", "solid_no" );
 	}
-
-	if ( g_MutaMode == "mutation19" )
+	else if ( g_MutaMode == "mutation19" )
 	{
 		// Multiple tunnel stuck spawns that aren't accessible in Survival,
 		// that need to only be fixed for Taaannnk! Mutation. Navmesh is

--- a/root/scripts/vscripts/community/maps/c8m3_sewers.nut
+++ b/root/scripts/vscripts/community/maps/c8m3_sewers.nut
@@ -71,7 +71,7 @@ function DoRoundFixes()
 
 		EntFire( "washer_lift_button2", "AddOutput", "OnPressed " + g_UpdateName + "_shortcut_booster_TMP*:Kill::0:-1" );
 	}
-	if ( g_BaseMode == "survival" )
+	else if ( g_BaseMode == "survival" )
 	{
 		devchap( "BASE SURVIVAL" );
 

--- a/root/scripts/vscripts/community/maps/c8m5_rooftop.nut
+++ b/root/scripts/vscripts/community/maps/c8m5_rooftop.nut
@@ -54,17 +54,20 @@ function DoRoundFixes()
 
 		make_ladder( "_ladder_saferoomlulz_cloned_rooftopmain", "5924 8561.1 6018", "13896 2362 -447", "0 90 0", "0 1 0", 0 );
 
-		// Get nav tiles by position because IDS can change if edited later on
-		local navMain1 = NavMesh.GetNearestNavArea(Vector(5575.740234, 8499.918945, 6097.730957), 16, true, true);
-		local navMain2 = NavMesh.GetNearestNavArea(Vector(5575.740234, 8450.000000, 6097.730957), 16, true, true);
-		local navConnection1 = NavMesh.GetNearestNavArea(Vector(5518.500000, 8468.500000, 6000.031250), 16, true, true);
-		local navConnection2 = NavMesh.GetNearestNavArea(Vector(5627.500000, 8495.000000, 6153.142578), 16, true, true);
-		local navConnection3 = NavMesh.GetNearestNavArea(Vector(5627.500000, 8442.500000, 6153.142578), 16, true, true);
-		local navConnection4 = NavMesh.GetNearestNavArea(Vector(5575.740234, 8412.500000, 6097.730957), 16, true, true);
-		navConnection1.Disconnect(navMain1);
-		navConnection2.Disconnect(navMain1);
-		navConnection3.Disconnect(navMain2);
-		navConnection4.Disconnect(navMain2);
+		if ( g_MutaMode == "coop" || g_MutaMode == "realism" )
+		{
+			// Get nav tiles by position because IDS can change if edited later on
+			local navMain1 = NavMesh.GetNearestNavArea(Vector(5575.740234, 8499.918945, 6097.730957), 16, true, true);
+			local navMain2 = NavMesh.GetNearestNavArea(Vector(5575.740234, 8450.000000, 6097.730957), 16, true, true);
+			local navConnection1 = NavMesh.GetNearestNavArea(Vector(5518.500000, 8468.500000, 6000.031250), 16, true, true);
+			local navConnection2 = NavMesh.GetNearestNavArea(Vector(5627.500000, 8495.000000, 6153.142578), 16, true, true);
+			local navConnection3 = NavMesh.GetNearestNavArea(Vector(5627.500000, 8442.500000, 6153.142578), 16, true, true);
+			local navConnection4 = NavMesh.GetNearestNavArea(Vector(5575.740234, 8412.500000, 6097.730957), 16, true, true);
+			navConnection1.Disconnect(navMain1);
+			navConnection2.Disconnect(navMain1);
+			navConnection3.Disconnect(navMain2);
+			navConnection4.Disconnect(navMain2);
+		}
 	}
 	else if ( g_BaseMode == "scavenge" )
 	{

--- a/root/scripts/vscripts/community/maps/c8m5_rooftop.nut
+++ b/root/scripts/vscripts/community/maps/c8m5_rooftop.nut
@@ -66,7 +66,7 @@ function DoRoundFixes()
 		navConnection3.Disconnect(navMain2);
 		navConnection4.Disconnect(navMain2);
 	}
-	if ( g_BaseMode == "scavenge" )
+	else if ( g_BaseMode == "scavenge" )
 	{
 		devchap( "BASE SCAVENGE" );
 

--- a/root/scripts/vscripts/community/maps/c9m2_lots.nut
+++ b/root/scripts/vscripts/community/maps/c9m2_lots.nut
@@ -38,13 +38,14 @@ function DoRoundFixes()
 
 		EntFire( "finale_button_unlocker", "AddOutput", "OnEntireTeamEndTouch finaleswitch_initial:Lock::0:-1" );
 	}
-	if ( g_BaseMode == "coop" || g_BaseMode == "realism" )
+	else
 	{
 		// Get nav tiles by position because IDS can change if edited later on
 		local navMain = NavMesh.GetNearestNavArea(Vector(4766.412109, 7269.738281, 96.031250), 16, true, true)
 		local navConnection = NavMesh.GetNearestNavArea(Vector(4803.833984, 7260.107422, 128.313324), 16, true, true)
 		navConnection.Disconnect(navMain);
 	}
+
 	if ( HasPlayerControlledZombies() )
 	{
 		make_brush( "_losfix_gen1a",		"-1 -24 -8",	"1 24 8",	"6853 5881 50" );
@@ -91,8 +92,7 @@ function DoRoundFixes()
 
 		kill_entity( Entities.FindByClassnameNearest( "prop_dynamic", Vector( 8521, 5815, 348 ), 1 ) );
 	}
-
-	if ( g_MutaMode == "mutation19" )
+	else if ( g_MutaMode == "mutation19" )
 	{
 		// Slightly extend a func_playerinfected_clip back further behind
 		// starting safe room to fully block all navmesh behind there.

--- a/root/scripts/vscripts/community/maps/c9m2_lots.nut
+++ b/root/scripts/vscripts/community/maps/c9m2_lots.nut
@@ -38,7 +38,7 @@ function DoRoundFixes()
 
 		EntFire( "finale_button_unlocker", "AddOutput", "OnEntireTeamEndTouch finaleswitch_initial:Lock::0:-1" );
 	}
-	else
+	else if ( g_MutaMode == "coop" || g_MutaMode == "realism" )
 	{
 		// Get nav tiles by position because IDS can change if edited later on
 		local navMain = NavMesh.GetNearestNavArea(Vector(4766.412109, 7269.738281, 96.031250), 16, true, true)


### PR DESCRIPTION
By submitting, I acknowledge the topic has been discussed (issues or elsewhere), that I know what is required of compiled assets (CONTRIBUTING.md -> Coordination), and if these are text or script files I'll submit un-modified live game files first.

## What exactly is changed and why?

This PR aims to reduce the collateral damage of the newly introduced VScript God spots of [2f44245](https://github.com/Tsuey/L4D2-Community-Update/pull/479/commits/2f4424516da0f1f8cb67f7a815a6855ed6e0fd78) in #479 following the spirit of #505. It simply optimizes the `if else` clauses and activates the God spots only in Campaign and Realism modes (the ones used by speedrunners), thus excluding almost all mutations, which never signed up for that new _feature_.

## Is there anything specific that needs review?

No, though I haven't tested it ingame since the changes are so basic.

## Does this address any open issues?

No.